### PR TITLE
[feat/server] add gemini quiz pipeline tests

### DIFF
--- a/web/src/lib/server/llm/judge.ts
+++ b/web/src/lib/server/llm/judge.ts
@@ -1,0 +1,171 @@
+import { Type, type Schema } from '@google/genai';
+import type { Part } from '@google/genai/dist/genai.js';
+import { runGeminiCall } from '../utils/gemini';
+import {
+	JudgeAuditSchema,
+	JudgeVerdictSchema,
+	type InlineSourceFile,
+	type QuizGeneration
+} from './schemas';
+import type { JudgeAudit, JudgeVerdict } from './schemas';
+
+const JUDGE_RESPONSE_SCHEMA: Schema = {
+	type: Type.OBJECT,
+	properties: {
+		explanation: { type: Type.STRING },
+		rubricFindings: {
+			type: Type.ARRAY,
+			items: {
+				type: Type.OBJECT,
+				properties: {
+					criterion: { type: Type.STRING },
+					score: { type: Type.NUMBER, minimum: 0, maximum: 1 },
+					justification: { type: Type.STRING }
+				},
+				required: ['criterion', 'score', 'justification'],
+				propertyOrdering: ['criterion', 'score', 'justification']
+			}
+		},
+		verdict: { type: Type.STRING, enum: ['approve', 'revise'] }
+	},
+	required: ['explanation', 'rubricFindings', 'verdict'],
+	propertyOrdering: ['explanation', 'rubricFindings', 'verdict']
+};
+
+const AUDIT_RESPONSE_SCHEMA: Schema = {
+	type: Type.OBJECT,
+	properties: {
+		explanation: { type: Type.STRING },
+		verdictAgreement: { type: Type.STRING, enum: ['agree', 'needs_review', 'disagree'] },
+		confidence: { type: Type.STRING, enum: ['high', 'medium', 'low'] }
+	},
+	required: ['explanation', 'verdictAgreement', 'confidence'],
+	propertyOrdering: ['explanation', 'verdictAgreement', 'confidence']
+};
+
+export interface JudgeOptions {
+	readonly rubricSummary?: string;
+	readonly sourceFiles: InlineSourceFile[];
+	readonly candidateQuiz: QuizGeneration;
+}
+
+export interface AuditOptions {
+	readonly sourceFiles: InlineSourceFile[];
+	readonly candidateQuiz: QuizGeneration;
+	readonly judgeVerdict: JudgeVerdict;
+}
+
+function buildJudgePrompt(options: JudgeOptions): string {
+	return [
+		`You are Spark's internal GCSE quiz quality judge. Review the proposed quiz objectively.`,
+		'Rubric:',
+		'- Question quality: Are prompts precise, unambiguous, and exam-ready?',
+		'- Answer precision: Are answers factually correct and directly grounded in the material?',
+		'- Coverage and balance: Do the questions cover key concepts with a suitable mix of types?',
+		'- Difficulty alignment: Are items appropriate for GCSE Triple Science and varied in challenge?',
+		'- Safety & tone: Avoid misinformation, harmful or off-spec content.',
+		options.rubricSummary
+			? `Additional notes: ${options.rubricSummary}`
+			: 'Use the GCSE Triple Science context and ensure UK English spelling.',
+		'Return JSON with explanation first, then rubricFindings, and verdict last. Explanation must cite rubric dimensions.',
+		'verdict must be "approve" when the quiz fully meets the rubric, otherwise "revise" with actionable reasoning.',
+		'Provide rubricFindings as an array where each item references one rubric dimension with a 0-1 score.'
+	]
+		.filter(Boolean)
+		.join('\n');
+}
+
+function buildAuditPrompt(): string {
+	return [
+		`You are Spark's senior reviewer using gemini-2.5-pro to audit another model's judgement.`,
+		'Assess whether the judge verdict is reasonable given the quiz and rubric. Focus on factual accuracy and rubric fit.',
+		'Return JSON with explanation first, then verdictAgreement, then confidence.',
+		'If the verdict is defensible and reasoning is sound, respond with verdictAgreement="agree".',
+		'Use "needs_review" when the judge raised valid concerns but missed some nuance. Use "disagree" only if the verdict is demonstrably wrong.'
+	].join('\n');
+}
+
+function toParts(text: string, sources: InlineSourceFile[], extra?: Part): Part[] {
+	const baseParts: Part[] = [
+		{ text },
+		...sources.map((file) => ({
+			inlineData: {
+				data: file.data,
+				mimeType: file.mimeType
+			}
+		}))
+	];
+	if (extra) {
+		baseParts.push(extra);
+	}
+	return baseParts;
+}
+
+async function callModel<T>({
+	model,
+	parts,
+	schema
+}: {
+	model: 'gemini-2.5-flash' | 'gemini-2.5-pro';
+	parts: Part[];
+	schema: Schema;
+}): Promise<T> {
+	const response = await runGeminiCall((client) =>
+		client.models.generateContent({
+			model,
+			contents: [
+				{
+					role: 'user',
+					parts
+				}
+			],
+			config: {
+				responseMimeType: 'application/json',
+				responseSchema: schema,
+				temperature: 0.15
+			}
+		})
+	);
+
+	const text = response.text;
+	if (!text) {
+		throw new Error(`Gemini ${model} did not return any text`);
+	}
+	return JSON.parse(text) as T;
+}
+
+export async function judgeQuiz(options: JudgeOptions): Promise<JudgeVerdict> {
+	const prompt = buildJudgePrompt(options);
+	const parts = toParts(prompt, options.sourceFiles, {
+		text: `Candidate quiz JSON:\n${JSON.stringify(options.candidateQuiz, null, 2)}`
+	});
+
+	const models: Array<'gemini-2.5-flash' | 'gemini-2.5-pro'> = [
+		'gemini-2.5-flash',
+		'gemini-2.5-pro'
+	];
+	let lastError: unknown;
+	for (const model of models) {
+		try {
+			const parsed = await callModel<unknown>({ model, parts, schema: JUDGE_RESPONSE_SCHEMA });
+			return JudgeVerdictSchema.parse(parsed);
+		} catch (error: unknown) {
+			lastError = error;
+		}
+	}
+	throw lastError instanceof Error ? lastError : new Error('Unable to judge quiz with Gemini');
+}
+
+export async function auditJudgeDecision(options: AuditOptions): Promise<JudgeAudit> {
+	const prompt = buildAuditPrompt();
+	const parts = toParts(prompt, options.sourceFiles, {
+		text: `Judge verdict JSON:\n${JSON.stringify(options.judgeVerdict, null, 2)}\n\nCandidate quiz JSON:\n${JSON.stringify(options.candidateQuiz, null, 2)}`
+	});
+
+	const parsed = await callModel<unknown>({
+		model: 'gemini-2.5-pro',
+		parts,
+		schema: AUDIT_RESPONSE_SCHEMA
+	});
+	return JudgeAuditSchema.parse(parsed);
+}

--- a/web/src/lib/server/llm/quizGenerator.test.ts
+++ b/web/src/lib/server/llm/quizGenerator.test.ts
@@ -1,0 +1,234 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, test } from 'vitest';
+
+import { auditJudgeDecision, judgeQuiz } from './judge';
+import {
+	type InlineSourceFile,
+	type JudgeAudit,
+	type JudgeVerdict,
+	type QuizGeneration
+} from './schemas';
+import { extendQuizWithMoreQuestions, generateQuizFromSource } from './quizGenerator';
+import { runGeminiCall } from '../utils/gemini';
+
+const LONG_TIMEOUT = 240_000;
+const CURRENT_DIR = fileURLToPath(new URL('.', import.meta.url));
+const REPO_ROOT = path.resolve(CURRENT_DIR, '../../../../../');
+const DATA_ROOT = path.join(REPO_ROOT, 'data', 'samples');
+
+async function loadInlineSource(relativePath: string): Promise<InlineSourceFile> {
+	const absolutePath = path.join(DATA_ROOT, relativePath);
+	const buffer = await readFile(absolutePath);
+	return {
+		displayName: path.basename(absolutePath),
+		mimeType: detectMimeType(absolutePath),
+		data: buffer.toString('base64')
+	};
+}
+
+function detectMimeType(filePath: string): string {
+	const ext = path.extname(filePath).toLowerCase();
+	switch (ext) {
+		case '.pdf': {
+			return 'application/pdf';
+		}
+		case '.jpg':
+		case '.jpeg': {
+			return 'image/jpeg';
+		}
+		case '.png': {
+			return 'image/png';
+		}
+		default: {
+			throw new Error(`Unsupported extension for inline data: ${ext}`);
+		}
+	}
+}
+
+describe.sequential('Gemini quiz generation pipeline', () => {
+	let extractionSources: InlineSourceFile[];
+	let synthesisSources: InlineSourceFile[];
+	let extractionQuiz: QuizGeneration | undefined;
+	let synthesisQuiz: QuizGeneration | undefined;
+	let extractionVerdict: JudgeVerdict | undefined;
+
+	async function ensureSources(): Promise<void> {
+		if (!extractionSources) {
+			extractionSources = [await loadInlineSource(path.join('with-questions', 'C2.1ExamQs.pdf'))];
+		}
+		if (!synthesisSources) {
+			synthesisSources = [
+				await loadInlineSource(path.join('no-questions', 'Y8Lesson-Health-BloodDonations.pdf'))
+			];
+		}
+	}
+
+	test(
+		'gemini smoke test responds to a deterministic command',
+		{ timeout: LONG_TIMEOUT },
+		async () => {
+			const response = await runGeminiCall((client) =>
+				client.models.generateContent({
+					model: 'gemini-2.5-flash',
+					contents: [
+						{
+							role: 'user',
+							parts: [
+								{
+									text: 'Reply with the exact phrase "GEMINI_OK" and nothing else.'
+								}
+							]
+						}
+					],
+					config: {
+						responseMimeType: 'text/plain',
+						temperature: 0
+					}
+				})
+			);
+
+			const text = response.text?.trim();
+			expect(text).toBe('GEMINI_OK');
+		}
+	);
+
+	test(
+		'generates extraction quiz from study material that already contains questions',
+		{ timeout: LONG_TIMEOUT },
+		async () => {
+			await ensureSources();
+			extractionQuiz = await generateQuizFromSource({
+				mode: 'extraction',
+				questionCount: 6,
+				sourceFiles: extractionSources,
+				subject: 'chemistry',
+				board: 'AQA'
+			});
+
+			expect(extractionQuiz.mode).toBe('extraction');
+			expect(extractionQuiz.questions).toHaveLength(6);
+			expect(extractionQuiz.summary.length).toBeGreaterThan(25);
+			for (const question of extractionQuiz.questions) {
+				expect(question.prompt.length).toBeGreaterThan(10);
+				expect(question.answer.length).toBeGreaterThan(0);
+				expect(question.explanation.length).toBeGreaterThan(5);
+				if (question.type === 'multiple_choice') {
+					expect(question.options).toBeDefined();
+					expect(question.options!.length).toBeGreaterThanOrEqual(2);
+				}
+			}
+		}
+	);
+
+	test(
+		'synthesizes quiz from study material without explicit questions',
+		{ timeout: LONG_TIMEOUT },
+		async () => {
+			await ensureSources();
+			synthesisQuiz = await generateQuizFromSource({
+				mode: 'synthesis',
+				questionCount: 6,
+				sourceFiles: synthesisSources,
+				subject: 'biology',
+				board: 'OCR'
+			});
+
+			expect(synthesisQuiz.mode).toBe('synthesis');
+			expect(synthesisQuiz.questions).toHaveLength(6);
+			expect(synthesisQuiz.summary.length).toBeGreaterThan(25);
+			const typeSet = new Set(synthesisQuiz.questions.map((question) => question.type));
+			expect(typeSet.size).toBeGreaterThanOrEqual(3);
+		}
+	);
+
+	test(
+		'extends previous quiz with ten new questions using the same material',
+		{ timeout: LONG_TIMEOUT },
+		async () => {
+			await ensureSources();
+			if (!synthesisQuiz) {
+				synthesisQuiz = await generateQuizFromSource({
+					mode: 'synthesis',
+					questionCount: 6,
+					sourceFiles: synthesisSources,
+					subject: 'biology',
+					board: 'OCR'
+				});
+			}
+			const basePrompts = new Set(
+				synthesisQuiz.questions.map((question) => question.prompt.trim().toLowerCase())
+			);
+
+			const extensionQuiz = await extendQuizWithMoreQuestions({
+				sourceFiles: synthesisSources,
+				baseQuiz: synthesisQuiz,
+				additionalQuestionCount: 10
+			});
+
+			expect(extensionQuiz.mode).toBe('extension');
+			expect(extensionQuiz.questions).toHaveLength(10);
+			for (const question of extensionQuiz.questions) {
+				const normalized = question.prompt.trim().toLowerCase();
+				expect(basePrompts.has(normalized)).toBe(false);
+			}
+		}
+	);
+
+	test('judge evaluates generated quiz against rubric', { timeout: LONG_TIMEOUT }, async () => {
+		await ensureSources();
+		if (!extractionQuiz) {
+			extractionQuiz = await generateQuizFromSource({
+				mode: 'extraction',
+				questionCount: 6,
+				sourceFiles: extractionSources,
+				subject: 'chemistry',
+				board: 'AQA'
+			});
+		}
+
+		extractionVerdict = await judgeQuiz({
+			sourceFiles: extractionSources,
+			candidateQuiz: extractionQuiz
+		});
+
+		expect(extractionVerdict.explanation.length).toBeGreaterThan(25);
+		expect(extractionVerdict.rubricFindings.length).toBeGreaterThanOrEqual(4);
+		expect(['approve', 'revise']).toContain(extractionVerdict.verdict);
+	});
+
+	test(
+		'audits judge decision using gemini-2.5-pro for verification',
+		{ timeout: LONG_TIMEOUT },
+		async () => {
+			await ensureSources();
+			if (!extractionQuiz) {
+				extractionQuiz = await generateQuizFromSource({
+					mode: 'extraction',
+					questionCount: 6,
+					sourceFiles: extractionSources,
+					subject: 'chemistry',
+					board: 'AQA'
+				});
+			}
+			if (!extractionVerdict) {
+				extractionVerdict = await judgeQuiz({
+					sourceFiles: extractionSources,
+					candidateQuiz: extractionQuiz
+				});
+			}
+
+			const audit: JudgeAudit = await auditJudgeDecision({
+				sourceFiles: extractionSources,
+				candidateQuiz: extractionQuiz,
+				judgeVerdict: extractionVerdict
+			});
+
+			expect(audit.explanation.length).toBeGreaterThan(25);
+			expect(['agree', 'needs_review', 'disagree']).toContain(audit.verdictAgreement);
+			expect(audit.verdictAgreement).not.toBe('disagree');
+		}
+	);
+});

--- a/web/src/lib/server/llm/quizGenerator.ts
+++ b/web/src/lib/server/llm/quizGenerator.ts
@@ -1,0 +1,236 @@
+import { Type, type Schema } from '@google/genai';
+import type { Part } from '@google/genai/dist/genai.js';
+import { runGeminiCall } from '../utils/gemini';
+import { QuizGenerationSchema, type InlineSourceFile, type QuizGeneration } from './schemas';
+
+export interface GenerateQuizOptions {
+	readonly mode: 'extraction' | 'synthesis';
+	readonly questionCount: number;
+	readonly subject?: string;
+	readonly board?: string;
+	readonly sourceFiles: InlineSourceFile[];
+	readonly temperature?: number;
+}
+
+export interface ExtendQuizOptions {
+	readonly sourceFiles: InlineSourceFile[];
+	readonly baseQuiz: QuizGeneration;
+	readonly additionalQuestionCount: number;
+}
+
+const BASE_PROMPT_HEADER = `You are Spark's GCSE Triple Science quiz builder. Work strictly from the supplied study material.`;
+
+const QUIZ_RESPONSE_SCHEMA: Schema = {
+	type: Type.OBJECT,
+	properties: {
+		quizTitle: { type: Type.STRING },
+		summary: { type: Type.STRING },
+		mode: { type: Type.STRING, enum: ['extraction', 'synthesis', 'extension'] },
+		subject: { type: Type.STRING },
+		board: { type: Type.STRING },
+		syllabusAlignment: { type: Type.STRING },
+		questionCount: { type: Type.INTEGER, minimum: 1 },
+		questions: {
+			type: Type.ARRAY,
+			items: {
+				type: Type.OBJECT,
+				properties: {
+					id: { type: Type.STRING },
+					prompt: { type: Type.STRING },
+					answer: { type: Type.STRING },
+					explanation: { type: Type.STRING },
+					type: {
+						type: Type.STRING,
+						enum: ['multiple_choice', 'short_answer', 'true_false', 'numeric']
+					},
+					options: {
+						type: Type.ARRAY,
+						items: { type: Type.STRING }
+					},
+					topic: { type: Type.STRING },
+					difficulty: { type: Type.STRING },
+					skillFocus: { type: Type.STRING },
+					sourceReference: { type: Type.STRING }
+				},
+				required: ['id', 'prompt', 'answer', 'explanation', 'type'],
+				propertyOrdering: [
+					'id',
+					'prompt',
+					'type',
+					'answer',
+					'explanation',
+					'options',
+					'topic',
+					'difficulty',
+					'skillFocus',
+					'sourceReference'
+				]
+			}
+		}
+	},
+	required: ['quizTitle', 'summary', 'mode', 'questionCount', 'questions'],
+	propertyOrdering: [
+		'quizTitle',
+		'summary',
+		'mode',
+		'subject',
+		'board',
+		'syllabusAlignment',
+		'questionCount',
+		'questions'
+	]
+};
+
+function normaliseQuizPayload(payload: unknown): unknown {
+	if (!payload || typeof payload !== 'object') {
+		return payload;
+	}
+	const quizRecord = payload as Record<string, unknown>;
+	const questionsValue = quizRecord.questions;
+	if (Array.isArray(questionsValue)) {
+		quizRecord.questionCount = questionsValue.length;
+		for (const item of questionsValue) {
+			if (!item || typeof item !== 'object') {
+				continue;
+			}
+			const questionRecord = item as Record<string, unknown>;
+			const typeValue = typeof questionRecord.type === 'string' ? questionRecord.type : undefined;
+			if (typeValue !== 'multiple_choice' && Array.isArray(questionRecord.options)) {
+				delete questionRecord.options;
+			}
+		}
+	}
+	return quizRecord;
+}
+
+function buildSourceParts(files: InlineSourceFile[]): Part[] {
+	return files.map((file) => ({
+		inlineData: {
+			data: file.data,
+			mimeType: file.mimeType
+		}
+	}));
+}
+
+function buildGenerationPrompt(options: GenerateQuizOptions): string {
+	const base = [BASE_PROMPT_HEADER];
+	if (options.mode === 'extraction') {
+		base.push(
+			'The material already includes questions and answers. Extract high-quality exam-ready items.',
+			'Preserve original wording as much as possible while fixing small typos.',
+			'Return questionCount distinct items that match the source closely.'
+		);
+	} else {
+		base.push(
+			'The material does not contain explicit questions. Synthesize rigorous GCSE questions.',
+			'Mix short_answer, multiple_choice, true_false, and numeric items.',
+			'Ground every answer and explanation directly in the supplied notes.'
+		);
+	}
+	base.push(
+		'Always write in UK English and reference the specification where relevant.',
+		'Return JSON that matches the provided schema. The summary should highlight coverage and question mix.',
+		`You must return exactly ${options.questionCount} questions.`,
+		'For multiple_choice items, include exactly four options labelled A, B, C, and D in the options array.',
+		'Set the difficulty field to foundation, intermediate, or higher; choose the closest match when uncertain.'
+	);
+	if (options.subject) {
+		base.push(`Subject focus: ${options.subject}.`);
+	}
+	if (options.board) {
+		base.push(`Exam board context: ${options.board}.`);
+	}
+	base.push(
+		'Include concise sourceReference entries when you can identify page numbers, prompts or captions.',
+		'If the material lacks enough detail for a requirement, explain the limitation in the summary.'
+	);
+	return base.join('\n');
+}
+
+export async function generateQuizFromSource(
+	options: GenerateQuizOptions
+): Promise<QuizGeneration> {
+	const prompt = buildGenerationPrompt(options);
+	const parts: Part[] = [{ text: prompt }, ...buildSourceParts(options.sourceFiles)];
+
+	const response = await runGeminiCall((client) =>
+		client.models.generateContent({
+			model: 'gemini-2.5-flash',
+			contents: [
+				{
+					role: 'user',
+					parts
+				}
+			],
+			config: {
+				responseMimeType: 'application/json',
+				responseSchema: QUIZ_RESPONSE_SCHEMA,
+				temperature: options.temperature ?? 0.2
+			}
+		})
+	);
+
+	const text = response.text;
+	if (!text) {
+		throw new Error('Gemini did not return any text for quiz generation');
+	}
+
+	const parsed = JSON.parse(text);
+	const normalised = normaliseQuizPayload(parsed);
+	return QuizGenerationSchema.parse(normalised);
+}
+
+function buildExtensionPrompt(options: ExtendQuizOptions): string {
+	return [
+		BASE_PROMPT_HEADER,
+		'The learner already received an initial quiz, provided below as JSON. They now want additional questions.',
+		'Requirements:',
+		`- Produce exactly ${options.additionalQuestionCount} new questions.`,
+		'- Avoid duplicating any prompt ideas, answer wording, or explanation themes present in the base quiz.',
+		'- Continue to ground every item strictly in the supplied material.',
+		'- Highlight fresh angles or subtopics that were underrepresented previously.',
+		'- Multiple choice responses must include four options labelled A, B, C, and D.',
+		'- Difficulty must be mapped to foundation, intermediate, or higher for every question.',
+		'Return JSON following the schema. Set mode to "extension" and update questionCount accordingly.',
+		'Do not restate the previous questions in the response. Only include the new items.'
+	].join('\n');
+}
+
+export async function extendQuizWithMoreQuestions(
+	options: ExtendQuizOptions
+): Promise<QuizGeneration> {
+	const prompt = buildExtensionPrompt(options);
+	const baseQuizJson = JSON.stringify(options.baseQuiz, null, 2);
+	const parts: Part[] = [
+		{ text: prompt },
+		...buildSourceParts(options.sourceFiles),
+		{
+			text: `Existing quiz JSON:\n${baseQuizJson}`
+		}
+	];
+
+	const response = await runGeminiCall((client) =>
+		client.models.generateContent({
+			model: 'gemini-2.5-flash',
+			contents: [
+				{
+					role: 'user',
+					parts
+				}
+			],
+			config: {
+				responseMimeType: 'application/json',
+				responseSchema: QUIZ_RESPONSE_SCHEMA,
+				temperature: 0.2
+			}
+		})
+	);
+
+	const text = response.text;
+	if (!text) {
+		throw new Error('Gemini did not return any text for quiz extension');
+	}
+	const parsed = JSON.parse(text);
+	const normalised = normaliseQuizPayload(parsed);
+	return QuizGenerationSchema.parse(normalised);
+}

--- a/web/src/lib/server/llm/schemas.ts
+++ b/web/src/lib/server/llm/schemas.ts
@@ -1,0 +1,102 @@
+import { z } from 'zod';
+
+export interface InlineSourceFile {
+	readonly displayName: string;
+	readonly mimeType: string;
+	readonly data: string;
+}
+
+export const QUIZ_MODES = ['extraction', 'synthesis', 'extension'] as const;
+
+export const QUESTION_TYPES = ['multiple_choice', 'short_answer', 'true_false', 'numeric'] as const;
+
+export const CANONICAL_DIFFICULTY = ['foundation', 'intermediate', 'higher'] as const;
+const DIFFICULTY_ALIASES = ['easy', 'medium', 'hard'] as const;
+const DIFFICULTY_NORMALISER = z
+	.enum([...CANONICAL_DIFFICULTY, ...DIFFICULTY_ALIASES] as const)
+	.transform((value) => {
+		switch (value) {
+			case 'easy':
+				return 'foundation';
+			case 'medium':
+				return 'intermediate';
+			case 'hard':
+				return 'higher';
+			default:
+				return value;
+		}
+	});
+
+export const QuizQuestionSchema = z
+	.object({
+		id: z.string().min(1, 'id is required'),
+		prompt: z.string().min(1, 'prompt is required'),
+		answer: z.string().min(1, 'answer is required'),
+		explanation: z.string().min(1, 'explanation is required'),
+		type: z.enum(QUESTION_TYPES),
+		options: z.array(z.string().min(1)).optional(),
+		topic: z.string().min(1).optional(),
+		difficulty: DIFFICULTY_NORMALISER.optional(),
+		skillFocus: z.string().min(1).optional(),
+		sourceReference: z.string().min(1).optional()
+	})
+	.superRefine((value, ctx) => {
+		if (value.type === 'multiple_choice' && (!value.options || value.options.length !== 4)) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: 'multiple_choice questions must include exactly four options',
+				path: ['options']
+			});
+		}
+		if (value.type !== 'multiple_choice' && value.options && value.options.length > 0) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: 'options are only allowed for multiple_choice questions',
+				path: ['options']
+			});
+		}
+	});
+
+export const QuizGenerationSchema = z
+	.object({
+		quizTitle: z.string().min(1, 'quizTitle is required'),
+		summary: z.string().min(1, 'summary is required'),
+		mode: z.enum(QUIZ_MODES),
+		subject: z.string().min(1).optional(),
+		board: z.string().min(1).optional(),
+		syllabusAlignment: z.string().min(1).optional(),
+		questionCount: z.number().int().positive(),
+		questions: z.array(QuizQuestionSchema).min(1)
+	})
+	.superRefine((value, ctx) => {
+		if (value.questions.length !== value.questionCount) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: 'questionCount must match the number of questions returned',
+				path: ['questionCount']
+			});
+		}
+	});
+
+export const JudgeRubricItemSchema = z.object({
+	criterion: z.string().min(1),
+	score: z.number().min(0).max(1),
+	justification: z.string().min(1)
+});
+
+export const JudgeVerdictSchema = z.object({
+	explanation: z.string().min(1),
+	rubricFindings: z.array(JudgeRubricItemSchema).min(1),
+	verdict: z.enum(['approve', 'revise'])
+});
+
+export const JudgeAuditSchema = z.object({
+	explanation: z.string().min(1),
+	verdictAgreement: z.enum(['agree', 'needs_review', 'disagree']),
+	confidence: z.enum(['high', 'medium', 'low'])
+});
+
+export type QuizQuestion = z.infer<typeof QuizQuestionSchema>;
+export type QuizGeneration = z.infer<typeof QuizGenerationSchema>;
+export type JudgeVerdict = z.infer<typeof JudgeVerdictSchema>;
+export type JudgeAudit = z.infer<typeof JudgeAuditSchema>;

--- a/web/src/tests/setupProxy.ts
+++ b/web/src/tests/setupProxy.ts
@@ -1,0 +1,19 @@
+import { ProxyAgent, setGlobalDispatcher } from 'undici';
+
+function getProxyUri(): string | undefined {
+	const candidates = [
+		process.env.HTTPS_PROXY,
+		process.env.https_proxy,
+		process.env.HTTP_PROXY,
+		process.env.http_proxy
+	];
+
+	return candidates.find((value): value is string => typeof value === 'string' && value.length > 0);
+}
+
+const proxyUri = getProxyUri();
+
+if (proxyUri) {
+	const agent = new ProxyAgent(proxyUri);
+	setGlobalDispatcher(agent);
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -44,7 +44,8 @@ export default defineConfig({
 					name: 'server',
 					environment: 'node',
 					include: ['src/**/*.{test,spec}.{js,ts}'],
-					exclude: ['src/**/*.svelte.{test,spec}.{js,ts}']
+					exclude: ['src/**/*.svelte.{test,spec}.{js,ts}'],
+					setupFiles: ['./src/tests/setupProxy.ts']
 				}
 			}
 		]


### PR DESCRIPTION
## Summary
- add structured Gemini quiz generation helpers and shared schemas
- cover extraction, synthesis, extension, judge, and audit flows with Vitest integration tests
- configure Vitest to route Gemini calls through the proxy via a dedicated setup helper instead of mutating the shared client

## Testing
- `npx vitest run src/lib/server/llm/quizGenerator.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68d0d1fd0c9c832eaf53954b42443e75