### PR TITLE
Add quiz preview generator and admin viewer

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -42,6 +42,7 @@
 				"tailwind-merge": "^3.3.1",
 				"tailwind-variants": "^1.0.0",
 				"tailwindcss": "^4.0.0",
+				"tsx": "^4.19.2",
 				"tw-animate-css": "^1.3.8",
 				"typescript": "^5.0.0",
 				"typescript-eslint": "^8.20.0",
@@ -5669,6 +5670,19 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/get-tsconfig": {
+			"version": "4.10.1",
+			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
+			"integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"resolve-pkg-maps": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+			}
+		},
 		"node_modules/glob": {
 			"version": "10.4.5",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
@@ -7749,6 +7763,16 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/resolve-pkg-maps": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+			"integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+			}
+		},
 		"node_modules/retry": {
 			"version": "0.13.1",
 			"resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
@@ -8606,6 +8630,41 @@
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"dev": true,
 			"license": "0BSD"
+		},
+		"node_modules/tsx": {
+			"version": "4.20.5",
+			"resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.5.tgz",
+			"integrity": "sha512-+wKjMNU9w/EaQayHXb7WA7ZaHY6hN8WgfvHNQ3t1PnU91/7O8TcTnIhCDYTZwnt8JsO9IBqZ30Ln1r7pPF52Aw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"esbuild": "~0.25.0",
+				"get-tsconfig": "^4.7.5"
+			},
+			"bin": {
+				"tsx": "dist/cli.mjs"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.3"
+			}
+		},
+		"node_modules/tsx/node_modules/fsevents": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
 		},
 		"node_modules/tw-animate-css": {
 			"version": "1.3.8",

--- a/web/package.json
+++ b/web/package.json
@@ -16,7 +16,8 @@
 		"format": "prettier --write .",
 		"lint": "prettier --check . && eslint .",
 		"test:unit": "vitest",
-		"test": "npm run test:unit -- --run"
+		"test": "npm run test:unit -- --run",
+		"generate:sample-previews": "tsx --tsconfig scripts/tsconfig.scripts.json scripts/generate-sample-previews.ts"
 	},
 	"devDependencies": {
 		"@eslint/compat": "^1.2.5",
@@ -55,6 +56,7 @@
 		"tailwindcss": "^4.0.0",
 		"tw-animate-css": "^1.3.8",
 		"typescript": "^5.0.0",
+		"tsx": "^4.19.2",
 		"typescript-eslint": "^8.20.0",
 		"vite": "^7.0.4",
 		"vite-plugin-devtools-json": "^1.0.0",

--- a/web/scripts/generate-sample-previews.ts
+++ b/web/scripts/generate-sample-previews.ts
@@ -1,0 +1,322 @@
+import { mkdir, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { generateQuizFromSource } from '../src/lib/server/llm/quizGenerator';
+import type { InlineSourceFile, QuizGeneration } from '../src/lib/server/llm/schemas';
+
+type QuizMode = 'extraction' | 'synthesis';
+
+type SampleFile = {
+	readonly absolutePath: string;
+	readonly relativePath: string;
+	readonly mode: QuizMode;
+};
+
+type ManifestItem = {
+	readonly id: string;
+	readonly sequence: number;
+	readonly mode: QuizMode;
+	readonly sourceFile: string;
+	readonly sourceDisplayName: string;
+	readonly resultPath: string;
+	readonly status: 'ok' | 'error';
+	readonly questionCount?: number;
+	readonly quizTitle?: string;
+	readonly summary?: string;
+	readonly subject?: string;
+	readonly board?: string;
+	readonly errorMessage?: string;
+};
+
+type PersistedQuizBase = {
+	readonly sequence: number;
+	readonly mode: QuizMode;
+	readonly sourceFile: string;
+	readonly sourceDisplayName: string;
+	readonly generatedAt: string;
+	readonly subjectGuess?: string;
+	readonly boardGuess?: string;
+};
+
+type PersistedQuizSuccess = PersistedQuizBase & {
+	readonly status: 'ok';
+	readonly quiz: QuizGeneration;
+};
+
+type PersistedQuizError = PersistedQuizBase & {
+	readonly status: 'error';
+	readonly error: {
+		readonly message: string;
+		readonly stack?: string;
+	};
+};
+
+type PersistedQuiz = PersistedQuizSuccess | PersistedQuizError;
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const webRoot = path.resolve(__dirname, '..');
+const repoRoot = path.resolve(webRoot, '..');
+const dataRoot = path.join(repoRoot, 'data', 'samples');
+const previewRoot = path.join(webRoot, 'static', 'admin-preview');
+const quizOutputRoot = path.join(previewRoot, 'quizzes');
+const manifestPath = path.join(previewRoot, 'manifest.json');
+
+const ALLOWED_EXTENSIONS = new Set(['.pdf', '.png', '.jpg', '.jpeg']);
+const QUESTION_COUNT_BY_MODE: Record<QuizMode, number> = {
+	extraction: 6,
+	synthesis: 6
+};
+
+async function listSampleFiles(): Promise<SampleFile[]> {
+	const results: SampleFile[] = [];
+	async function walk(currentRelative: string): Promise<void> {
+		const absolute = path.join(dataRoot, currentRelative);
+		const entries = await readdir(absolute, { withFileTypes: true });
+		for (const entry of entries) {
+			if (entry.name.startsWith('.')) {
+				continue;
+			}
+			const nextRelative = path.join(currentRelative, entry.name);
+			const nextAbsolute = path.join(dataRoot, nextRelative);
+			if (entry.isDirectory()) {
+				await walk(nextRelative);
+				continue;
+			}
+			const extension = path.extname(entry.name).toLowerCase();
+			if (!ALLOWED_EXTENSIONS.has(extension)) {
+				console.warn(`Skipping unsupported file extension for ${nextRelative}`);
+				continue;
+			}
+			const mode = resolveMode(nextRelative);
+			results.push({
+				absolutePath: nextAbsolute,
+				relativePath: nextRelative.replace(/\\/g, '/'),
+				mode
+			});
+		}
+	}
+	await walk('');
+	results.sort((a, b) => a.relativePath.localeCompare(b.relativePath));
+	return results;
+}
+
+function resolveMode(relativePath: string): QuizMode {
+	const normalised = relativePath.replace(/\\/g, '/');
+	if (normalised.includes('with-questions/')) {
+		return 'extraction';
+	}
+	if (normalised.includes('no-questions/')) {
+		return 'synthesis';
+	}
+	throw new Error(`Unable to determine quiz mode for ${relativePath}`);
+}
+
+function guessSubject(relativePath: string): string | undefined {
+	const name = relativePath.toLowerCase();
+	if (name.includes('chem')) {
+		return 'chemistry';
+	}
+	if (name.includes('phys')) {
+		return 'physics';
+	}
+	if (name.includes('bio') || name.includes('health') || name.includes('blood')) {
+		return 'biology';
+	}
+	return undefined;
+}
+
+function guessBoard(relativePath: string): string | undefined {
+	const name = relativePath.toLowerCase();
+	if (name.includes('aqa')) {
+		return 'AQA';
+	}
+	if (name.includes('ocr')) {
+		return 'OCR';
+	}
+	if (name.includes('edexcel')) {
+		return 'Edexcel';
+	}
+	return undefined;
+}
+
+async function loadInlineSource(file: SampleFile): Promise<InlineSourceFile> {
+	const buffer = await readFile(file.absolutePath);
+	const mimeType = detectMimeType(file.absolutePath);
+	return {
+		displayName: path.basename(file.absolutePath),
+		mimeType,
+		data: buffer.toString('base64')
+	};
+}
+
+function detectMimeType(filePath: string): string {
+	const ext = path.extname(filePath).toLowerCase();
+	switch (ext) {
+		case '.pdf':
+			return 'application/pdf';
+		case '.jpg':
+		case '.jpeg':
+			return 'image/jpeg';
+		case '.png':
+			return 'image/png';
+		default:
+			throw new Error(`Unsupported file extension: ${ext}`);
+	}
+}
+
+function toSlug(value: string): string {
+	return value
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, '-')
+		.replace(/^-+|-+$/g, '')
+		.replace(/-{2,}/g, '-');
+}
+
+function ensureSafeId(base: string, sequence: number): string {
+	const slug = toSlug(base);
+	const padded = sequence.toString().padStart(3, '0');
+	return `${padded}-${slug}`;
+}
+
+async function ensureDataDirectories(): Promise<void> {
+	const stats = await stat(dataRoot).catch(() => undefined);
+	if (!stats || !stats.isDirectory()) {
+		throw new Error(`Expected data directory at ${dataRoot}`);
+	}
+}
+
+async function main(): Promise<void> {
+	await ensureDataDirectories();
+	const sampleFiles = await listSampleFiles();
+	if (sampleFiles.length === 0) {
+		console.warn('No sample files found. Nothing to do.');
+		return;
+	}
+
+	await rm(previewRoot, { recursive: true, force: true });
+	await mkdir(quizOutputRoot, { recursive: true });
+
+	const runTimestamp = new Date().toISOString();
+	const manifestItems: ManifestItem[] = [];
+
+	for (let index = 0; index < sampleFiles.length; index += 1) {
+		const sample = sampleFiles[index]!;
+		const sequence = index + 1;
+		const subjectGuess = guessSubject(sample.relativePath);
+		const boardGuess = guessBoard(sample.relativePath);
+		const questionCount = QUESTION_COUNT_BY_MODE[sample.mode];
+		console.log(
+			`Generating quiz for [${sequence}/${sampleFiles.length}] ${sample.relativePath} (${sample.mode})`
+		);
+
+		const id = ensureSafeId(sample.relativePath, sequence);
+		const resultFileName = `${id}.json`;
+		const resultPath = path.join('quizzes', resultFileName);
+		const inline = await loadInlineSource(sample);
+
+		try {
+			const quiz = await generateQuizFromSource({
+				mode: sample.mode,
+				questionCount,
+				subject: subjectGuess,
+				board: boardGuess,
+				sourceFiles: [inline]
+			});
+
+			const persisted: PersistedQuiz = {
+				status: 'ok',
+				sequence,
+				mode: sample.mode,
+				sourceFile: `data/samples/${sample.relativePath}`,
+				sourceDisplayName: inline.displayName,
+				generatedAt: runTimestamp,
+				subjectGuess,
+				boardGuess,
+				quiz
+			};
+			await writeFile(
+				path.join(previewRoot, resultPath),
+				JSON.stringify(persisted, null, 2),
+				'utf8'
+			);
+
+			manifestItems.push({
+				id,
+				sequence,
+				mode: sample.mode,
+				sourceFile: persisted.sourceFile,
+				sourceDisplayName: inline.displayName,
+				resultPath,
+				status: 'ok',
+				questionCount: quiz.questionCount,
+				quizTitle: quiz.quizTitle,
+				summary: quiz.summary,
+				subject: quiz.subject ?? subjectGuess,
+				board: quiz.board ?? boardGuess
+			});
+
+			console.log(` → Saved preview to ${resultPath}`);
+		} catch (error) {
+			const message =
+				error instanceof Error ? error.message || 'Unknown Gemini error' : 'Unknown Gemini error';
+			const stack = error instanceof Error ? error.stack : undefined;
+
+			const persisted: PersistedQuiz = {
+				status: 'error',
+				sequence,
+				mode: sample.mode,
+				sourceFile: `data/samples/${sample.relativePath}`,
+				sourceDisplayName: inline.displayName,
+				generatedAt: runTimestamp,
+				subjectGuess,
+				boardGuess,
+				error: {
+					message,
+					stack
+				}
+			};
+
+			await writeFile(
+				path.join(previewRoot, resultPath),
+				JSON.stringify(persisted, null, 2),
+				'utf8'
+			);
+
+			manifestItems.push({
+				id,
+				sequence,
+				mode: sample.mode,
+				sourceFile: persisted.sourceFile,
+				sourceDisplayName: inline.displayName,
+				resultPath,
+				status: 'error',
+				subject: subjectGuess,
+				board: boardGuess,
+				errorMessage: message
+			});
+
+			console.error(` ✖ Failed to generate preview for ${sample.relativePath}: ${message}`);
+		}
+	}
+
+	const manifest = {
+		generatedAt: runTimestamp,
+		itemCount: manifestItems.length,
+		items: manifestItems
+	} satisfies {
+		generatedAt: string;
+		itemCount: number;
+		items: ManifestItem[];
+	};
+
+	await writeFile(manifestPath, JSON.stringify(manifest, null, 2), 'utf8');
+	console.log(`Wrote manifest with ${manifestItems.length} entries to ${manifestPath}`);
+}
+
+main().catch((error) => {
+	console.error('Failed to generate quiz previews');
+	console.error(error instanceof Error ? (error.stack ?? error.message) : error);
+	process.exitCode = 1;
+});

--- a/web/scripts/stubs/$env/static/private.ts
+++ b/web/scripts/stubs/$env/static/private.ts
@@ -1,0 +1,9 @@
+const key = process.env.GEMINI_API_KEY;
+
+if (!key) {
+	throw new Error(
+		'GEMINI_API_KEY environment variable is required to run the sample preview generator.'
+	);
+}
+
+export const GEMINI_API_KEY: string = key;

--- a/web/scripts/tsconfig.scripts.json
+++ b/web/scripts/tsconfig.scripts.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../tsconfig.json",
+	"compilerOptions": {
+		"baseUrl": "..",
+		"paths": {
+			"$env/static/private": ["scripts/stubs/$env/static/private.ts"]
+		}
+	}
+}

--- a/web/src/lib/components/admin/app-sidebar.svelte
+++ b/web/src/lib/components/admin/app-sidebar.svelte
@@ -2,6 +2,7 @@
 	import HomeIcon from '@lucide/svelte/icons/home';
 	import BotIcon from '@lucide/svelte/icons/bot';
 	import DatabaseIcon from '@lucide/svelte/icons/database';
+	import FileTextIcon from '@lucide/svelte/icons/file-text';
 	import LogOutIcon from '@lucide/svelte/icons/log-out';
 	import MoreVerticalIcon from '@lucide/svelte/icons/more-vertical';
 	import * as Avatar from '$lib/components/ui/avatar/index.js';
@@ -37,6 +38,12 @@
 			href: '/admin/gemini',
 			icon: BotIcon,
 			highlight: (path) => path.startsWith('/admin/gemini')
+		},
+		{
+			title: 'Quiz previews',
+			href: '/admin/quiz-previews',
+			icon: FileTextIcon,
+			highlight: (path) => path.startsWith('/admin/quiz-previews')
 		}
 	];
 

--- a/web/src/routes/admin/quiz-previews/+page.server.ts
+++ b/web/src/routes/admin/quiz-previews/+page.server.ts
@@ -1,0 +1,137 @@
+import { error } from '@sveltejs/kit';
+import { z } from 'zod';
+
+import { QuizGenerationSchema, QUIZ_MODES } from '$lib/server/llm/schemas';
+
+import type { PageServerLoad } from './$types';
+
+const QuizModeSchema = z.enum(QUIZ_MODES);
+
+const ManifestItemSchema = z
+	.object({
+		id: z.string().min(1),
+		sequence: z.number().int().positive(),
+		mode: QuizModeSchema,
+		sourceFile: z.string().min(1),
+		sourceDisplayName: z.string().min(1),
+		resultPath: z.string().min(1),
+		status: z.enum(['ok', 'error']),
+		questionCount: z.number().int().positive().optional(),
+		quizTitle: z.string().min(1).optional(),
+		summary: z.string().min(1).optional(),
+		subject: z.string().min(1).optional(),
+		board: z.string().min(1).optional(),
+		errorMessage: z.string().min(1).optional()
+	})
+	.superRefine((value, ctx) => {
+		if (value.status === 'ok' && typeof value.questionCount !== 'number') {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: 'questionCount is required when status is ok',
+				path: ['questionCount']
+			});
+		}
+		if (value.status === 'error' && !value.errorMessage) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: 'errorMessage is required when status is error',
+				path: ['errorMessage']
+			});
+		}
+	});
+
+const ManifestSchema = z
+	.object({
+		generatedAt: z.string().min(1),
+		itemCount: z.number().int().nonnegative(),
+		items: z.array(ManifestItemSchema)
+	})
+	.superRefine((value, ctx) => {
+		if (value.items.length !== value.itemCount) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: 'itemCount must match the number of manifest entries',
+				path: ['itemCount']
+			});
+		}
+	});
+
+const PersistedQuizBaseSchema = z.object({
+	status: z.enum(['ok', 'error']),
+	sequence: z.number().int().positive(),
+	mode: QuizModeSchema,
+	sourceFile: z.string().min(1),
+	sourceDisplayName: z.string().min(1),
+	generatedAt: z.string().min(1),
+	subjectGuess: z.string().min(1).optional(),
+	boardGuess: z.string().min(1).optional()
+});
+
+const PersistedQuizSuccessSchema = PersistedQuizBaseSchema.extend({
+	status: z.literal('ok'),
+	quiz: QuizGenerationSchema
+});
+
+const PersistedQuizErrorSchema = PersistedQuizBaseSchema.extend({
+	status: z.literal('error'),
+	error: z.object({
+		message: z.string().min(1),
+		stack: z.string().min(1).optional()
+	})
+});
+
+const PersistedQuizSchema = z.union([PersistedQuizSuccessSchema, PersistedQuizErrorSchema]);
+
+export type Manifest = z.infer<typeof ManifestSchema>;
+export type ManifestItem = z.infer<typeof ManifestItemSchema>;
+export type PersistedQuiz = z.infer<typeof PersistedQuizSchema>;
+
+const PREVIEW_BASE_PATH = '/admin-preview';
+
+export const load: PageServerLoad = async ({ fetch }) => {
+	const response = await fetch(`${PREVIEW_BASE_PATH}/manifest.json`, {
+		headers: { 'cache-control': 'no-cache' }
+	});
+	if (!response.ok) {
+		throw error(response.status, 'Failed to load preview manifest');
+	}
+	const manifestJson = await response.json();
+	const manifest = ManifestSchema.parse(manifestJson);
+
+	const previews: Record<string, PersistedQuiz> = {};
+	for (const item of manifest.items) {
+		const detailResponse = await fetch(`${PREVIEW_BASE_PATH}/${item.resultPath}`, {
+			headers: { 'cache-control': 'no-cache' }
+		});
+		if (!detailResponse.ok) {
+			previews[item.id] = {
+				status: 'error',
+				sequence: item.sequence,
+				mode: item.mode,
+				sourceFile: item.sourceFile,
+				sourceDisplayName: item.sourceDisplayName,
+				generatedAt: manifest.generatedAt,
+				subjectGuess: item.subject,
+				boardGuess: item.board,
+				error: {
+					message: `Failed to load preview JSON (${detailResponse.status})`
+				}
+			};
+			continue;
+		}
+		const detailJson = await detailResponse.json();
+		previews[item.id] = PersistedQuizSchema.parse(detailJson);
+	}
+
+	return {
+		manifest,
+		previews,
+		initialSelectionId: manifest.items[0]?.id ?? null,
+		previewBasePath: PREVIEW_BASE_PATH
+	} satisfies {
+		manifest: Manifest;
+		previews: Record<string, PersistedQuiz>;
+		initialSelectionId: string | null;
+		previewBasePath: string;
+	};
+};

--- a/web/src/routes/admin/quiz-previews/+page.svelte
+++ b/web/src/routes/admin/quiz-previews/+page.svelte
@@ -1,0 +1,334 @@
+<script lang="ts">
+	import { resolve } from '$app/paths';
+	import * as Card from '$lib/components/ui/card/index.js';
+	import { buttonVariants } from '$lib/components/ui/button/index.js';
+	import { Separator } from '$lib/components/ui/separator/index.js';
+	import { cn } from '$lib/utils.js';
+
+	import type { PageData } from './$types';
+	import type { ManifestItem } from './+page.server';
+
+	const MODE_LABELS: Record<ManifestItem['mode'], string> = {
+		extraction: 'Extraction',
+		synthesis: 'Synthesis'
+	};
+
+	const STATUS_LABELS: Record<'ok' | 'error', string> = {
+		ok: 'Ready',
+		error: 'Needs attention'
+	};
+
+	const STATUS_CLASSES: Record<'ok' | 'error', string> = {
+		ok: 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400',
+		error: 'bg-red-500/10 text-red-600 dark:text-red-400'
+	};
+
+	const QUESTION_TYPE_LABELS: Record<string, string> = {
+		multiple_choice: 'Multiple choice',
+		short_answer: 'Short answer',
+		true_false: 'True or false',
+		numeric: 'Numeric'
+	};
+
+	let { data }: { data: PageData } = $props();
+
+	let selectedId = $state<string | null>(data.initialSelectionId);
+
+	const manifest = data.manifest;
+	const previews = data.previews;
+	const previewBasePath = data.previewBasePath;
+
+	const selectedItem = $derived(() => {
+		if (!selectedId) {
+			return null;
+		}
+		return manifest.items.find((item) => item.id === selectedId) ?? null;
+	});
+
+	const selectedPreview = $derived(() => {
+		if (!selectedId) {
+			return null;
+		}
+		return previews[selectedId] ?? null;
+	});
+
+	const allErrored = $derived(
+		() => manifest.items.length > 0 && manifest.items.every((item) => item.status === 'error')
+	);
+
+	function formatMode(mode: ManifestItem['mode']): string {
+		return MODE_LABELS[mode] ?? mode;
+	}
+
+	function formatStatus(status: 'ok' | 'error'): string {
+		return STATUS_LABELS[status] ?? status;
+	}
+
+	function formatDate(value: string): string {
+		try {
+			const date = new Date(value);
+			if (Number.isNaN(date.getTime())) {
+				return value;
+			}
+			return new Intl.DateTimeFormat('en-GB', {
+				dateStyle: 'medium',
+				timeStyle: 'short',
+				hour12: false
+			}).format(date);
+		} catch {
+			return value;
+		}
+	}
+
+	function handleSelect(item: ManifestItem): void {
+		selectedId = item.id;
+	}
+
+	function getQuestionTypeLabel(type: string): string {
+		return QUESTION_TYPE_LABELS[type] ?? type.replace(/_/g, ' ');
+	}
+</script>
+
+<div class="mx-auto w-full max-w-6xl space-y-6">
+	<Card.Root>
+		<Card.Header>
+			<Card.Title>Quiz generation previews</Card.Title>
+			<Card.Description>
+				Offline snapshots generated from <code>data/samples</code> for quick review in the admin console.
+			</Card.Description>
+		</Card.Header>
+		<Card.Content class="space-y-3 text-sm text-muted-foreground">
+			<p>
+				Run <code>npm run generate:sample-previews</code> inside <code>web/</code> to refresh these
+				files. The tool reprocesses every sample asset and writes JSON results to
+				<code>static/admin-preview</code>.
+			</p>
+			<p>
+				Last generated: <span class="font-medium text-foreground"
+					>{formatDate(manifest.generatedAt)}</span
+				>.
+				{#if allErrored}
+					<span class="ml-2 text-red-600 dark:text-red-400">
+						All previews failed to generate; rerun the tool once Gemini access is available.
+					</span>
+				{/if}
+			</p>
+		</Card.Content>
+	</Card.Root>
+
+	<div class="grid gap-4 lg:grid-cols-[320px_1fr]">
+		<Card.Root class="h-fit">
+			<Card.Header class="pb-3">
+				<Card.Title class="text-base">Sample files</Card.Title>
+				<Card.Description>Select a source asset to inspect its saved output.</Card.Description>
+			</Card.Header>
+			<Card.Content class="space-y-2">
+				{#if manifest.items.length === 0}
+					<p class="text-sm text-muted-foreground">No preview files were found.</p>
+				{:else}
+					<ul class="space-y-2">
+						{#each manifest.items as item (item.id)}
+							<li>
+								<button
+									type="button"
+									class={cn(
+										'w-full rounded-lg border px-3 py-3 text-left transition hover:border-primary/60 hover:bg-muted/80',
+										selectedId === item.id ? 'border-primary bg-primary/5' : 'border-border'
+									)}
+									on:click={() => handleSelect(item)}
+								>
+									<div class="flex items-center justify-between gap-3">
+										<div>
+											<p class="text-sm font-semibold text-foreground">
+												#{item.sequence}
+												<span class="ml-2 font-normal text-muted-foreground">
+													{item.sourceDisplayName}
+												</span>
+											</p>
+											<p class="text-xs text-muted-foreground">
+												{formatMode(item.mode)} • {item.sourceFile}
+											</p>
+										</div>
+										<span
+											class={cn(
+												'rounded-full px-2 py-0.5 text-xs font-medium',
+												STATUS_CLASSES[item.status]
+											)}
+										>
+											{formatStatus(item.status)}
+										</span>
+									</div>
+									{#if item.status === 'ok'}
+										<p class="mt-2 text-xs text-muted-foreground">
+											{item.questionCount} questions · {item.quizTitle ?? 'Untitled quiz'}
+										</p>
+									{:else if item.errorMessage}
+										<p class="mt-2 text-xs text-red-600 dark:text-red-400">
+											{item.errorMessage}
+										</p>
+									{/if}
+								</button>
+							</li>
+						{/each}
+					</ul>
+				{/if}
+			</Card.Content>
+		</Card.Root>
+
+		<Card.Root class="min-h-[28rem]">
+			<Card.Header class="pb-3">
+				<Card.Title class="text-base">Preview details</Card.Title>
+				<Card.Description>Review the stored JSON output for the selected sample.</Card.Description>
+			</Card.Header>
+			<Separator />
+			<Card.Content class="space-y-4 pt-4">
+				{#if !selectedItem || !selectedPreview}
+					<p class="text-sm text-muted-foreground">Select a sample to see its stored preview.</p>
+				{:else}
+					<div class="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+						<span
+							>Source: <span class="font-medium text-foreground">{selectedItem.sourceFile}</span
+							></span
+						>
+						<span>•</span>
+						<span
+							>Mode: <span class="font-medium text-foreground">{formatMode(selectedItem.mode)}</span
+							></span
+						>
+						<span>•</span>
+						<span
+							>Generated: <span class="font-medium text-foreground"
+								>{formatDate(selectedPreview.generatedAt)}</span
+							></span
+						>
+						{#if selectedPreview.subjectGuess}
+							<span>•</span>
+							<span
+								>Subject guess: <span class="font-medium text-foreground"
+									>{selectedPreview.subjectGuess}</span
+								></span
+							>
+						{/if}
+						{#if selectedPreview.boardGuess}
+							<span>•</span>
+							<span
+								>Board guess: <span class="font-medium text-foreground"
+									>{selectedPreview.boardGuess}</span
+								></span
+							>
+						{/if}
+					</div>
+					<div class="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+						<a
+							class={cn(buttonVariants({ variant: 'outline', size: 'xs' }), 'mt-2')}
+							href={resolve(`${previewBasePath}/${selectedItem.resultPath}`)}
+							download
+						>
+							Download JSON
+						</a>
+						<a
+							class={cn(buttonVariants({ variant: 'ghost', size: 'xs' }), 'mt-2')}
+							href={resolve(`${previewBasePath}/${selectedItem.resultPath}`)}
+							target="_blank"
+							rel="noreferrer"
+						>
+							Open in new tab
+						</a>
+					</div>
+
+					{#if selectedPreview.status === 'error'}
+						<div
+							class="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700 dark:border-red-800 dark:bg-red-950/40 dark:text-red-300"
+						>
+							<p class="font-semibold">Generation failed</p>
+							<p class="mt-1">{selectedPreview.error.message}</p>
+							{#if selectedPreview.error.stack}
+								<details class="mt-2">
+									<summary
+										class="cursor-pointer text-xs font-medium text-red-600 dark:text-red-300"
+									>
+										View stack trace
+									</summary>
+									<pre class="mt-2 overflow-x-auto text-xs whitespace-pre-wrap">{selectedPreview
+											.error.stack}</pre>
+								</details>
+							{/if}
+						</div>
+					{:else}
+						<div class="space-y-4">
+							<div>
+								<h3 class="text-lg font-semibold text-foreground">
+									{selectedPreview.quiz.quizTitle}
+								</h3>
+								<p class="text-sm text-muted-foreground">{selectedPreview.quiz.summary}</p>
+							</div>
+							<div class="grid gap-4">
+								{#each selectedPreview.quiz.questions as question, index (question.id)}
+									<div class="rounded-lg border border-border bg-card/60 p-4">
+										<div
+											class="flex flex-wrap items-center justify-between gap-2 text-xs text-muted-foreground"
+										>
+											<span class="font-semibold text-foreground">Question {index + 1}</span>
+											<span
+												class="rounded-full bg-muted px-2 py-0.5 text-[11px] tracking-wide text-muted-foreground uppercase"
+											>
+												{getQuestionTypeLabel(question.type)}
+											</span>
+										</div>
+										<p class="mt-3 text-sm font-medium text-foreground">{question.prompt}</p>
+										{#if question.options && question.options.length > 0}
+											<ul class="mt-3 list-disc space-y-1 pl-5 text-sm text-muted-foreground">
+												{#each question.options as option, optIndex (`${question.id}-${optIndex}`)}
+													<li>
+														<span class="font-medium text-foreground"
+															>{String.fromCharCode(65 + optIndex)}.</span
+														>
+														<span class="ml-2">{option}</span>
+													</li>
+												{/each}
+											</ul>
+										{/if}
+										<div class="mt-4 space-y-2 text-sm">
+											<p>
+												<span class="font-semibold text-foreground">Answer:</span>
+												<span class="ml-2 text-muted-foreground">{question.answer}</span>
+											</p>
+											<p class="text-muted-foreground">
+												<span class="font-semibold text-foreground">Explanation:</span>
+												<span class="ml-2">{question.explanation}</span>
+											</p>
+											{#if question.sourceReference}
+												<p class="text-muted-foreground">
+													<span class="font-semibold text-foreground">Reference:</span>
+													<span class="ml-2">{question.sourceReference}</span>
+												</p>
+											{/if}
+											{#if question.topic || question.difficulty}
+												<div class="flex flex-wrap gap-3 text-xs text-muted-foreground">
+													{#if question.topic}
+														<span
+															>Topic: <span class="font-medium text-foreground"
+																>{question.topic}</span
+															></span
+														>
+													{/if}
+													{#if question.difficulty}
+														<span
+															>Difficulty: <span class="font-medium text-foreground"
+																>{question.difficulty}</span
+															></span
+														>
+													{/if}
+												</div>
+											{/if}
+										</div>
+									</div>
+								{/each}
+							</div>
+						</div>
+					{/if}
+				{/if}
+			</Card.Content>
+		</Card.Root>
+	</div>
+</div>

--- a/web/static/admin-preview/manifest.json
+++ b/web/static/admin-preview/manifest.json
@@ -1,0 +1,57 @@
+{
+  "generatedAt": "2025-09-22T08:24:35.756Z",
+  "itemCount": 5,
+  "items": [
+    {
+      "id": "001-no-questions-y8lesson-health-blooddonations-pdf",
+      "sequence": 1,
+      "mode": "synthesis",
+      "sourceFile": "data/samples/no-questions/Y8Lesson-Health-BloodDonations.pdf",
+      "sourceDisplayName": "Y8Lesson-Health-BloodDonations.pdf",
+      "resultPath": "quizzes/001-no-questions-y8lesson-health-blooddonations-pdf.json",
+      "status": "error",
+      "subject": "biology",
+      "errorMessage": "exception TypeError: fetch failed sending request"
+    },
+    {
+      "id": "002-with-questions-18fcf3eb-957a-4922-86c8-28cf0f1ca467-1-105-c-jpeg",
+      "sequence": 2,
+      "mode": "extraction",
+      "sourceFile": "data/samples/with-questions/18FCF3EB-957A-4922-86C8-28CF0F1CA467_1_105_c.jpeg",
+      "sourceDisplayName": "18FCF3EB-957A-4922-86C8-28CF0F1CA467_1_105_c.jpeg",
+      "resultPath": "quizzes/002-with-questions-18fcf3eb-957a-4922-86c8-28cf0f1ca467-1-105-c-jpeg.json",
+      "status": "error",
+      "errorMessage": "exception TypeError: fetch failed sending request"
+    },
+    {
+      "id": "003-with-questions-966860a9-bfd8-436c-958d-2470ed154da6-1-105-c-jpeg",
+      "sequence": 3,
+      "mode": "extraction",
+      "sourceFile": "data/samples/with-questions/966860A9-BFD8-436C-958D-2470ED154DA6_1_105_c.jpeg",
+      "sourceDisplayName": "966860A9-BFD8-436C-958D-2470ED154DA6_1_105_c.jpeg",
+      "resultPath": "quizzes/003-with-questions-966860a9-bfd8-436c-958d-2470ed154da6-1-105-c-jpeg.json",
+      "status": "error",
+      "errorMessage": "exception TypeError: fetch failed sending request"
+    },
+    {
+      "id": "004-with-questions-c2-1examqs-pdf",
+      "sequence": 4,
+      "mode": "extraction",
+      "sourceFile": "data/samples/with-questions/C2.1ExamQs.pdf",
+      "sourceDisplayName": "C2.1ExamQs.pdf",
+      "resultPath": "quizzes/004-with-questions-c2-1examqs-pdf.json",
+      "status": "error",
+      "errorMessage": "exception TypeError: fetch failed sending request"
+    },
+    {
+      "id": "005-with-questions-f503558b-56e2-4fb4-b7c9-788a6231bba3-1-105-c-jpeg",
+      "sequence": 5,
+      "mode": "extraction",
+      "sourceFile": "data/samples/with-questions/F503558B-56E2-4FB4-B7C9-788A6231BBA3_1_105_c.jpeg",
+      "sourceDisplayName": "F503558B-56E2-4FB4-B7C9-788A6231BBA3_1_105_c.jpeg",
+      "resultPath": "quizzes/005-with-questions-f503558b-56e2-4fb4-b7c9-788a6231bba3-1-105-c-jpeg.json",
+      "status": "error",
+      "errorMessage": "exception TypeError: fetch failed sending request"
+    }
+  ]
+}

--- a/web/static/admin-preview/quizzes/001-no-questions-y8lesson-health-blooddonations-pdf.json
+++ b/web/static/admin-preview/quizzes/001-no-questions-y8lesson-health-blooddonations-pdf.json
@@ -1,0 +1,13 @@
+{
+  "status": "error",
+  "sequence": 1,
+  "mode": "synthesis",
+  "sourceFile": "data/samples/no-questions/Y8Lesson-Health-BloodDonations.pdf",
+  "sourceDisplayName": "Y8Lesson-Health-BloodDonations.pdf",
+  "generatedAt": "2025-09-22T08:24:35.756Z",
+  "subjectGuess": "biology",
+  "error": {
+    "message": "exception TypeError: fetch failed sending request",
+    "stack": "Error: exception TypeError: fetch failed sending request\n    at <anonymous> (/workspace/spark/web/node_modules/@google/genai/src/_api_client.ts:600:13)\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\n    at async Models.Models.generateContent (/workspace/spark/web/node_modules/@google/genai/src/models.ts:76:14)\n    at async attemptWithRetries (/workspace/spark/web/src/lib/server/utils/gemini.ts:165:10)\n    at async runTask (/workspace/spark/web/src/lib/server/utils/gemini.ts:198:18)"
+  }
+}

--- a/web/static/admin-preview/quizzes/002-with-questions-18fcf3eb-957a-4922-86c8-28cf0f1ca467-1-105-c-jpeg.json
+++ b/web/static/admin-preview/quizzes/002-with-questions-18fcf3eb-957a-4922-86c8-28cf0f1ca467-1-105-c-jpeg.json
@@ -1,0 +1,12 @@
+{
+  "status": "error",
+  "sequence": 2,
+  "mode": "extraction",
+  "sourceFile": "data/samples/with-questions/18FCF3EB-957A-4922-86C8-28CF0F1CA467_1_105_c.jpeg",
+  "sourceDisplayName": "18FCF3EB-957A-4922-86C8-28CF0F1CA467_1_105_c.jpeg",
+  "generatedAt": "2025-09-22T08:24:35.756Z",
+  "error": {
+    "message": "exception TypeError: fetch failed sending request",
+    "stack": "Error: exception TypeError: fetch failed sending request\n    at <anonymous> (/workspace/spark/web/node_modules/@google/genai/src/_api_client.ts:600:13)\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\n    at async Models.Models.generateContent (/workspace/spark/web/node_modules/@google/genai/src/models.ts:76:14)\n    at async attemptWithRetries (/workspace/spark/web/src/lib/server/utils/gemini.ts:165:10)\n    at async runTask (/workspace/spark/web/src/lib/server/utils/gemini.ts:198:18)"
+  }
+}

--- a/web/static/admin-preview/quizzes/003-with-questions-966860a9-bfd8-436c-958d-2470ed154da6-1-105-c-jpeg.json
+++ b/web/static/admin-preview/quizzes/003-with-questions-966860a9-bfd8-436c-958d-2470ed154da6-1-105-c-jpeg.json
@@ -1,0 +1,12 @@
+{
+  "status": "error",
+  "sequence": 3,
+  "mode": "extraction",
+  "sourceFile": "data/samples/with-questions/966860A9-BFD8-436C-958D-2470ED154DA6_1_105_c.jpeg",
+  "sourceDisplayName": "966860A9-BFD8-436C-958D-2470ED154DA6_1_105_c.jpeg",
+  "generatedAt": "2025-09-22T08:24:35.756Z",
+  "error": {
+    "message": "exception TypeError: fetch failed sending request",
+    "stack": "Error: exception TypeError: fetch failed sending request\n    at <anonymous> (/workspace/spark/web/node_modules/@google/genai/src/_api_client.ts:600:13)\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\n    at async Models.Models.generateContent (/workspace/spark/web/node_modules/@google/genai/src/models.ts:76:14)\n    at async attemptWithRetries (/workspace/spark/web/src/lib/server/utils/gemini.ts:165:10)\n    at async runTask (/workspace/spark/web/src/lib/server/utils/gemini.ts:198:18)"
+  }
+}

--- a/web/static/admin-preview/quizzes/004-with-questions-c2-1examqs-pdf.json
+++ b/web/static/admin-preview/quizzes/004-with-questions-c2-1examqs-pdf.json
@@ -1,0 +1,12 @@
+{
+  "status": "error",
+  "sequence": 4,
+  "mode": "extraction",
+  "sourceFile": "data/samples/with-questions/C2.1ExamQs.pdf",
+  "sourceDisplayName": "C2.1ExamQs.pdf",
+  "generatedAt": "2025-09-22T08:24:35.756Z",
+  "error": {
+    "message": "exception TypeError: fetch failed sending request",
+    "stack": "Error: exception TypeError: fetch failed sending request\n    at <anonymous> (/workspace/spark/web/node_modules/@google/genai/src/_api_client.ts:600:13)\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\n    at async Models.Models.generateContent (/workspace/spark/web/node_modules/@google/genai/src/models.ts:76:14)\n    at async attemptWithRetries (/workspace/spark/web/src/lib/server/utils/gemini.ts:165:10)\n    at async runTask (/workspace/spark/web/src/lib/server/utils/gemini.ts:198:18)"
+  }
+}

--- a/web/static/admin-preview/quizzes/005-with-questions-f503558b-56e2-4fb4-b7c9-788a6231bba3-1-105-c-jpeg.json
+++ b/web/static/admin-preview/quizzes/005-with-questions-f503558b-56e2-4fb4-b7c9-788a6231bba3-1-105-c-jpeg.json
@@ -1,0 +1,12 @@
+{
+  "status": "error",
+  "sequence": 5,
+  "mode": "extraction",
+  "sourceFile": "data/samples/with-questions/F503558B-56E2-4FB4-B7C9-788A6231BBA3_1_105_c.jpeg",
+  "sourceDisplayName": "F503558B-56E2-4FB4-B7C9-788A6231BBA3_1_105_c.jpeg",
+  "generatedAt": "2025-09-22T08:24:35.756Z",
+  "error": {
+    "message": "exception TypeError: fetch failed sending request",
+    "stack": "Error: exception TypeError: fetch failed sending request\n    at <anonymous> (/workspace/spark/web/node_modules/@google/genai/src/_api_client.ts:600:13)\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\n    at async Models.Models.generateContent (/workspace/spark/web/node_modules/@google/genai/src/models.ts:76:14)\n    at async attemptWithRetries (/workspace/spark/web/src/lib/server/utils/gemini.ts:165:10)\n    at async runTask (/workspace/spark/web/src/lib/server/utils/gemini.ts:198:18)"
+  }
+}


### PR DESCRIPTION
## Summary
- add a tsx-powered CLI to batch run the quiz generator against data/samples and cache the results under static/admin-preview
- provide a stub for $env/static/private so the tool can reuse the server code path outside SvelteKit and document the npm script to rerun it
- introduce an /admin/quiz-previews page (wired into the sidebar) to browse the generated JSON snapshots, including error details when Gemini calls fail

## Testing
- npm run lint


------
https://chatgpt.com/codex/tasks/task_e_68d104a888d0832eaf7ed9df5295af3f