### PR TITLE
Add offline admin quiz preview tooling

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -42,6 +42,7 @@
 				"tailwind-merge": "^3.3.1",
 				"tailwind-variants": "^1.0.0",
 				"tailwindcss": "^4.0.0",
+				"tsx": "^4.20.5",
 				"tw-animate-css": "^1.3.8",
 				"typescript": "^5.0.0",
 				"typescript-eslint": "^8.20.0",
@@ -5669,6 +5670,19 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/get-tsconfig": {
+			"version": "4.10.1",
+			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
+			"integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"resolve-pkg-maps": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+			}
+		},
 		"node_modules/glob": {
 			"version": "10.4.5",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
@@ -7749,6 +7763,16 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/resolve-pkg-maps": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+			"integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+			}
+		},
 		"node_modules/retry": {
 			"version": "0.13.1",
 			"resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
@@ -8606,6 +8630,41 @@
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"dev": true,
 			"license": "0BSD"
+		},
+		"node_modules/tsx": {
+			"version": "4.20.5",
+			"resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.5.tgz",
+			"integrity": "sha512-+wKjMNU9w/EaQayHXb7WA7ZaHY6hN8WgfvHNQ3t1PnU91/7O8TcTnIhCDYTZwnt8JsO9IBqZ30Ln1r7pPF52Aw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"esbuild": "~0.25.0",
+				"get-tsconfig": "^4.7.5"
+			},
+			"bin": {
+				"tsx": "dist/cli.mjs"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.3"
+			}
+		},
+		"node_modules/tsx/node_modules/fsevents": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
 		},
 		"node_modules/tw-animate-css": {
 			"version": "1.3.8",

--- a/web/package.json
+++ b/web/package.json
@@ -16,7 +16,8 @@
 		"format": "prettier --write .",
 		"lint": "prettier --check . && eslint .",
 		"test:unit": "vitest",
-		"test": "npm run test:unit -- --run"
+		"test": "npm run test:unit -- --run",
+		"generate:admin-previews": "tsx --tsconfig ./tsconfig.json scripts/generate-admin-previews.ts"
 	},
 	"devDependencies": {
 		"@eslint/compat": "^1.2.5",
@@ -53,10 +54,11 @@
 		"tailwind-merge": "^3.3.1",
 		"tailwind-variants": "^1.0.0",
 		"tailwindcss": "^4.0.0",
-		"tw-animate-css": "^1.3.8",
-		"typescript": "^5.0.0",
-		"typescript-eslint": "^8.20.0",
-		"vite": "^7.0.4",
+               "tsx": "^4.20.5",
+               "tw-animate-css": "^1.3.8",
+               "typescript": "^5.0.0",
+               "typescript-eslint": "^8.20.0",
+               "vite": "^7.0.4",
 		"vite-plugin-devtools-json": "^1.0.0",
 		"vitest": "^3.2.3",
 		"vitest-browser-svelte": "^0.1.0",

--- a/web/scripts/generate-admin-previews.ts
+++ b/web/scripts/generate-admin-previews.ts
@@ -1,0 +1,256 @@
+#!/usr/bin/env node
+import { mkdir, readdir, readFile, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { GoogleGenAI } from '@google/genai';
+import { ProxyAgent, setGlobalDispatcher } from 'undici';
+
+import {
+	QUIZ_RESPONSE_SCHEMA,
+	buildGenerationPrompt,
+	buildSourceParts,
+	normaliseQuizPayload,
+	type GenerationPromptOptions
+} from '../src/lib/server/llm/generationCore';
+import {
+	QuizGenerationSchema,
+	type InlineSourceFile,
+	type QuizGeneration
+} from '../src/lib/server/llm/schemas';
+
+const DEFAULT_QUESTION_COUNT = 6;
+const SUBJECT_BY_MODE: Record<GenerationPromptOptions['mode'], string> = {
+	extraction: 'chemistry',
+	synthesis: 'biology'
+};
+const BOARD_BY_MODE: Record<GenerationPromptOptions['mode'], string> = {
+	extraction: 'AQA',
+	synthesis: 'OCR'
+};
+
+interface GenerateOptions extends GenerationPromptOptions {
+	readonly sourceFiles: InlineSourceFile[];
+}
+
+const SUPPORTED_EXTENSIONS = new Set(['.pdf', '.jpg', '.jpeg', '.png']);
+const GEMINI_MODEL_ID = 'gemini-2.5-flash';
+const DEFAULT_TEMPERATURE = 0.2;
+
+function createGeminiClient(): GoogleGenAI {
+	const apiKey = process.env.GEMINI_API_KEY;
+	if (!apiKey) {
+		throw new Error('GEMINI_API_KEY environment variable is required.');
+	}
+	return new GoogleGenAI({ apiKey });
+}
+
+function configureProxyAgent(): void {
+	const candidates = [
+		process.env.HTTPS_PROXY,
+		process.env.https_proxy,
+		process.env.HTTP_PROXY,
+		process.env.http_proxy
+	];
+	const proxy = candidates.find((value) => typeof value === 'string' && value.length > 0);
+	if (proxy) {
+		setGlobalDispatcher(new ProxyAgent(proxy));
+	}
+}
+
+configureProxyAgent();
+
+const geminiClient = createGeminiClient();
+
+interface PreviewIndexEntry {
+	readonly id: number;
+	readonly sourceRelativePath: string;
+	readonly mode: GenerationPromptOptions['mode'];
+	readonly subject?: string;
+	readonly board?: string;
+	readonly questionCount: number;
+	readonly outputFile: string;
+}
+
+interface PreviewDetail extends PreviewIndexEntry {
+	readonly quiz: unknown;
+}
+
+async function generateQuiz(options: GenerateOptions): Promise<QuizGeneration> {
+	const prompt = buildGenerationPrompt(options);
+	const parts = [{ text: prompt }, ...buildSourceParts(options.sourceFiles)];
+	const response = await geminiClient.models.generateContent({
+		model: GEMINI_MODEL_ID,
+		contents: [
+			{
+				role: 'user',
+				parts
+			}
+		],
+		config: {
+			responseMimeType: 'application/json',
+			responseSchema: QUIZ_RESPONSE_SCHEMA,
+			temperature: DEFAULT_TEMPERATURE
+		}
+	});
+
+	const text = response.text;
+	if (!text) {
+		throw new Error('Gemini returned an empty response for quiz generation.');
+	}
+
+	const parsed = JSON.parse(text);
+	const normalised = normaliseQuizPayload(parsed);
+	return QuizGenerationSchema.parse(normalised);
+}
+
+function detectMimeType(filePath: string): string {
+	const ext = path.extname(filePath).toLowerCase();
+	switch (ext) {
+		case '.pdf':
+			return 'application/pdf';
+		case '.jpg':
+		case '.jpeg':
+			return 'image/jpeg';
+		case '.png':
+			return 'image/png';
+		default:
+			throw new Error(`Unsupported file extension: ${ext}`);
+	}
+}
+
+async function listRelativeFiles(root: string, relative = ''): Promise<string[]> {
+	const absolute = path.join(root, relative);
+	const items = await readdir(absolute, { withFileTypes: true });
+	const files: string[] = [];
+	for (const item of items) {
+		if (item.isDirectory()) {
+			const nested = await listRelativeFiles(root, path.join(relative, item.name));
+			files.push(...nested);
+		} else if (item.isFile()) {
+			const entryPath = path.join(relative, item.name);
+			if (SUPPORTED_EXTENSIONS.has(path.extname(entryPath).toLowerCase())) {
+				files.push(entryPath);
+			}
+		}
+	}
+	return files;
+}
+
+async function loadInlineSourceFile(root: string, relativePath: string): Promise<InlineSourceFile> {
+	const absolutePath = path.join(root, relativePath);
+	const data = await readFile(absolutePath);
+	return {
+		displayName: path.basename(relativePath),
+		mimeType: detectMimeType(relativePath),
+		data: data.toString('base64')
+	};
+}
+
+function resolveMode(relativePath: string): GenerationPromptOptions['mode'] {
+	const [topLevel] = relativePath.split(path.sep);
+	if (topLevel === 'with-questions') {
+		return 'extraction';
+	}
+	return 'synthesis';
+}
+
+function normaliseRelativePath(relativePath: string): string {
+	return relativePath.split(path.sep).join('/');
+}
+
+async function main(): Promise<void> {
+	const currentFile = fileURLToPath(import.meta.url);
+	const scriptsDir = path.dirname(currentFile);
+	const webDir = path.resolve(scriptsDir, '..');
+	const repoRoot = path.resolve(webDir, '..');
+	const dataRoot = path.join(repoRoot, 'data', 'samples');
+	const outputDir = path.join(webDir, 'static', 'admin-preview-data');
+
+	await rm(outputDir, { recursive: true, force: true });
+	await mkdir(outputDir, { recursive: true });
+
+	const relativeFiles = await listRelativeFiles(dataRoot);
+	relativeFiles.sort((a, b) => a.localeCompare(b));
+
+	if (relativeFiles.length === 0) {
+		console.warn('[admin-previews] No sample files found.');
+		return;
+	}
+
+	const indexEntries: PreviewIndexEntry[] = [];
+	let counter = 0;
+
+	for (const relative of relativeFiles) {
+		counter += 1;
+		const mode = resolveMode(relative);
+		const subject = SUBJECT_BY_MODE[mode];
+		const board = BOARD_BY_MODE[mode];
+		const inlineSource = await loadInlineSourceFile(dataRoot, relative);
+		const normalisedPath = normaliseRelativePath(relative);
+
+		console.log(
+			`[admin-previews] Generating ${mode} quiz for ${normalisedPath} (entry #${counter}).`
+		);
+
+		const quiz = await generateQuiz({
+			mode,
+			questionCount: DEFAULT_QUESTION_COUNT,
+			subject,
+			board,
+			sourceFiles: [inlineSource]
+		});
+
+		const outputFile = `preview-${String(counter).padStart(2, '0')}.json`;
+		const detail: PreviewDetail = {
+			id: counter,
+			sourceRelativePath: normalisedPath,
+			mode,
+			subject,
+			board,
+			questionCount: quiz.questionCount,
+			outputFile,
+			quiz
+		};
+
+		await writeFile(
+			path.join(outputDir, outputFile),
+			`${JSON.stringify(detail, null, 2)}\n`,
+			'utf8'
+		);
+
+		indexEntries.push({
+			id: detail.id,
+			sourceRelativePath: detail.sourceRelativePath,
+			mode: detail.mode,
+			subject: detail.subject,
+			board: detail.board,
+			questionCount: detail.questionCount,
+			outputFile: detail.outputFile
+		});
+	}
+
+	const indexPayload = {
+		generatedAt: new Date().toISOString(),
+		entries: indexEntries
+	};
+
+	await writeFile(
+		path.join(outputDir, 'index.json'),
+		`${JSON.stringify(indexPayload, null, 2)}\n`,
+		'utf8'
+	);
+
+	console.log(
+		`[admin-previews] Wrote ${indexEntries.length} previews to ${path.relative(
+			repoRoot,
+			outputDir
+		)}`
+	);
+}
+
+main().catch((error) => {
+	console.error('[admin-previews] Failed to generate previews.');
+	console.error(error);
+	process.exitCode = 1;
+});

--- a/web/src/lib/components/admin/app-sidebar.svelte
+++ b/web/src/lib/components/admin/app-sidebar.svelte
@@ -2,6 +2,7 @@
 	import HomeIcon from '@lucide/svelte/icons/home';
 	import BotIcon from '@lucide/svelte/icons/bot';
 	import DatabaseIcon from '@lucide/svelte/icons/database';
+	import ListChecksIcon from '@lucide/svelte/icons/list-checks';
 	import LogOutIcon from '@lucide/svelte/icons/log-out';
 	import MoreVerticalIcon from '@lucide/svelte/icons/more-vertical';
 	import * as Avatar from '$lib/components/ui/avatar/index.js';
@@ -37,6 +38,12 @@
 			href: '/admin/gemini',
 			icon: BotIcon,
 			highlight: (path) => path.startsWith('/admin/gemini')
+		},
+		{
+			title: 'Previews',
+			href: '/admin/previews',
+			icon: ListChecksIcon,
+			highlight: (path) => path.startsWith('/admin/previews')
 		}
 	];
 

--- a/web/src/lib/server/llm/generationCore.ts
+++ b/web/src/lib/server/llm/generationCore.ts
@@ -1,0 +1,139 @@
+import { Type, type Part, type Schema } from '@google/genai';
+
+import type { InlineSourceFile } from './schemas';
+
+export interface GenerationPromptOptions {
+	readonly mode: 'extraction' | 'synthesis';
+	readonly questionCount: number;
+	readonly subject?: string;
+	readonly board?: string;
+}
+
+export const BASE_PROMPT_HEADER = `You are Spark's GCSE Triple Science quiz builder. Work strictly from the supplied study material.`;
+
+export const QUIZ_RESPONSE_SCHEMA: Schema = {
+	type: Type.OBJECT,
+	properties: {
+		quizTitle: { type: Type.STRING },
+		summary: { type: Type.STRING },
+		mode: { type: Type.STRING, enum: ['extraction', 'synthesis', 'extension'] },
+		subject: { type: Type.STRING },
+		board: { type: Type.STRING },
+		syllabusAlignment: { type: Type.STRING },
+		questionCount: { type: Type.INTEGER, minimum: 1 },
+		questions: {
+			type: Type.ARRAY,
+			items: {
+				type: Type.OBJECT,
+				properties: {
+					id: { type: Type.STRING },
+					prompt: { type: Type.STRING },
+					answer: { type: Type.STRING },
+					explanation: { type: Type.STRING },
+					type: {
+						type: Type.STRING,
+						enum: ['multiple_choice', 'short_answer', 'true_false', 'numeric']
+					},
+					options: {
+						type: Type.ARRAY,
+						items: { type: Type.STRING }
+					},
+					topic: { type: Type.STRING },
+					difficulty: { type: Type.STRING },
+					skillFocus: { type: Type.STRING },
+					sourceReference: { type: Type.STRING }
+				},
+				required: ['id', 'prompt', 'answer', 'explanation', 'type'],
+				propertyOrdering: [
+					'id',
+					'prompt',
+					'type',
+					'answer',
+					'explanation',
+					'options',
+					'topic',
+					'difficulty',
+					'skillFocus',
+					'sourceReference'
+				]
+			}
+		}
+	},
+	required: ['quizTitle', 'summary', 'mode', 'questionCount', 'questions'],
+	propertyOrdering: [
+		'quizTitle',
+		'summary',
+		'mode',
+		'subject',
+		'board',
+		'syllabusAlignment',
+		'questionCount',
+		'questions'
+	]
+};
+
+export function normaliseQuizPayload(payload: unknown): unknown {
+	if (!payload || typeof payload !== 'object') {
+		return payload;
+	}
+	const quizRecord = payload as Record<string, unknown>;
+	const questionsValue = quizRecord.questions;
+	if (Array.isArray(questionsValue)) {
+		quizRecord.questionCount = questionsValue.length;
+		for (const item of questionsValue) {
+			if (!item || typeof item !== 'object') {
+				continue;
+			}
+			const questionRecord = item as Record<string, unknown>;
+			const typeValue = typeof questionRecord.type === 'string' ? questionRecord.type : undefined;
+			if (typeValue !== 'multiple_choice' && Array.isArray(questionRecord.options)) {
+				delete questionRecord.options;
+			}
+		}
+	}
+	return quizRecord;
+}
+
+export function buildSourceParts(files: InlineSourceFile[]): Part[] {
+	return files.map((file) => ({
+		inlineData: {
+			data: file.data,
+			mimeType: file.mimeType
+		}
+	}));
+}
+
+export function buildGenerationPrompt(options: GenerationPromptOptions): string {
+	const base = [BASE_PROMPT_HEADER];
+	if (options.mode === 'extraction') {
+		base.push(
+			'The material already includes questions and answers. Extract high-quality exam-ready items.',
+			'Preserve original wording as much as possible while fixing small typos.',
+			'Return questionCount distinct items that match the source closely.'
+		);
+	} else {
+		base.push(
+			'The material does not contain explicit questions. Synthesize rigorous GCSE questions.',
+			'Mix short_answer, multiple_choice, true_false, and numeric items.',
+			'Ground every answer and explanation directly in the supplied notes.'
+		);
+	}
+	base.push(
+		'Always write in UK English and reference the specification where relevant.',
+		'Return JSON that matches the provided schema. The summary should highlight coverage and question mix.',
+		`You must return exactly ${options.questionCount} questions.`,
+		'For multiple_choice items, include exactly four options labelled A, B, C, and D in the options array.',
+		'Set the difficulty field to foundation, intermediate, or higher; choose the closest match when uncertain.'
+	);
+	if (options.subject) {
+		base.push(`Subject focus: ${options.subject}.`);
+	}
+	if (options.board) {
+		base.push(`Exam board context: ${options.board}.`);
+	}
+	base.push(
+		'Include concise sourceReference entries when you can identify page numbers, prompts or captions.',
+		'If the material lacks enough detail for a requirement, explain the limitation in the summary.'
+	);
+	return base.join('\n');
+}

--- a/web/src/lib/server/llm/quizGenerator.ts
+++ b/web/src/lib/server/llm/quizGenerator.ts
@@ -1,13 +1,16 @@
-import { Type, type Schema } from '@google/genai';
 import type { Part } from '@google/genai';
 import { runGeminiCall } from '../utils/gemini';
+import {
+	BASE_PROMPT_HEADER,
+	QUIZ_RESPONSE_SCHEMA,
+	buildGenerationPrompt,
+	buildSourceParts,
+	normaliseQuizPayload,
+	type GenerationPromptOptions
+} from './generationCore';
 import { QuizGenerationSchema, type InlineSourceFile, type QuizGeneration } from './schemas';
 
-export interface GenerateQuizOptions {
-	readonly mode: 'extraction' | 'synthesis';
-	readonly questionCount: number;
-	readonly subject?: string;
-	readonly board?: string;
+export interface GenerateQuizOptions extends GenerationPromptOptions {
 	readonly sourceFiles: InlineSourceFile[];
 	readonly temperature?: number;
 }
@@ -16,135 +19,6 @@ export interface ExtendQuizOptions {
 	readonly sourceFiles: InlineSourceFile[];
 	readonly baseQuiz: QuizGeneration;
 	readonly additionalQuestionCount: number;
-}
-
-const BASE_PROMPT_HEADER = `You are Spark's GCSE Triple Science quiz builder. Work strictly from the supplied study material.`;
-
-const QUIZ_RESPONSE_SCHEMA: Schema = {
-	type: Type.OBJECT,
-	properties: {
-		quizTitle: { type: Type.STRING },
-		summary: { type: Type.STRING },
-		mode: { type: Type.STRING, enum: ['extraction', 'synthesis', 'extension'] },
-		subject: { type: Type.STRING },
-		board: { type: Type.STRING },
-		syllabusAlignment: { type: Type.STRING },
-		questionCount: { type: Type.INTEGER, minimum: 1 },
-		questions: {
-			type: Type.ARRAY,
-			items: {
-				type: Type.OBJECT,
-				properties: {
-					id: { type: Type.STRING },
-					prompt: { type: Type.STRING },
-					answer: { type: Type.STRING },
-					explanation: { type: Type.STRING },
-					type: {
-						type: Type.STRING,
-						enum: ['multiple_choice', 'short_answer', 'true_false', 'numeric']
-					},
-					options: {
-						type: Type.ARRAY,
-						items: { type: Type.STRING }
-					},
-					topic: { type: Type.STRING },
-					difficulty: { type: Type.STRING },
-					skillFocus: { type: Type.STRING },
-					sourceReference: { type: Type.STRING }
-				},
-				required: ['id', 'prompt', 'answer', 'explanation', 'type'],
-				propertyOrdering: [
-					'id',
-					'prompt',
-					'type',
-					'answer',
-					'explanation',
-					'options',
-					'topic',
-					'difficulty',
-					'skillFocus',
-					'sourceReference'
-				]
-			}
-		}
-	},
-	required: ['quizTitle', 'summary', 'mode', 'questionCount', 'questions'],
-	propertyOrdering: [
-		'quizTitle',
-		'summary',
-		'mode',
-		'subject',
-		'board',
-		'syllabusAlignment',
-		'questionCount',
-		'questions'
-	]
-};
-
-function normaliseQuizPayload(payload: unknown): unknown {
-	if (!payload || typeof payload !== 'object') {
-		return payload;
-	}
-	const quizRecord = payload as Record<string, unknown>;
-	const questionsValue = quizRecord.questions;
-	if (Array.isArray(questionsValue)) {
-		quizRecord.questionCount = questionsValue.length;
-		for (const item of questionsValue) {
-			if (!item || typeof item !== 'object') {
-				continue;
-			}
-			const questionRecord = item as Record<string, unknown>;
-			const typeValue = typeof questionRecord.type === 'string' ? questionRecord.type : undefined;
-			if (typeValue !== 'multiple_choice' && Array.isArray(questionRecord.options)) {
-				delete questionRecord.options;
-			}
-		}
-	}
-	return quizRecord;
-}
-
-function buildSourceParts(files: InlineSourceFile[]): Part[] {
-	return files.map((file) => ({
-		inlineData: {
-			data: file.data,
-			mimeType: file.mimeType
-		}
-	}));
-}
-
-function buildGenerationPrompt(options: GenerateQuizOptions): string {
-	const base = [BASE_PROMPT_HEADER];
-	if (options.mode === 'extraction') {
-		base.push(
-			'The material already includes questions and answers. Extract high-quality exam-ready items.',
-			'Preserve original wording as much as possible while fixing small typos.',
-			'Return questionCount distinct items that match the source closely.'
-		);
-	} else {
-		base.push(
-			'The material does not contain explicit questions. Synthesize rigorous GCSE questions.',
-			'Mix short_answer, multiple_choice, true_false, and numeric items.',
-			'Ground every answer and explanation directly in the supplied notes.'
-		);
-	}
-	base.push(
-		'Always write in UK English and reference the specification where relevant.',
-		'Return JSON that matches the provided schema. The summary should highlight coverage and question mix.',
-		`You must return exactly ${options.questionCount} questions.`,
-		'For multiple_choice items, include exactly four options labelled A, B, C, and D in the options array.',
-		'Set the difficulty field to foundation, intermediate, or higher; choose the closest match when uncertain.'
-	);
-	if (options.subject) {
-		base.push(`Subject focus: ${options.subject}.`);
-	}
-	if (options.board) {
-		base.push(`Exam board context: ${options.board}.`);
-	}
-	base.push(
-		'Include concise sourceReference entries when you can identify page numbers, prompts or captions.',
-		'If the material lacks enough detail for a requirement, explain the limitation in the summary.'
-	);
-	return base.join('\n');
 }
 
 export async function generateQuizFromSource(

--- a/web/src/lib/types/adminPreview.ts
+++ b/web/src/lib/types/adminPreview.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+
+import { QuizGenerationSchema } from '$lib/server/llm/schemas';
+
+const PREVIEW_MODES = ['extraction', 'synthesis'] as const;
+
+export const PreviewIndexEntrySchema = z.object({
+	id: z.number().int().positive(),
+	sourceRelativePath: z.string().min(1),
+	mode: z.enum(PREVIEW_MODES),
+	subject: z.string().min(1).optional(),
+	board: z.string().min(1).optional(),
+	questionCount: z.number().int().positive(),
+	outputFile: z.string().min(1)
+});
+
+export const PreviewDetailSchema = PreviewIndexEntrySchema.extend({
+	quiz: QuizGenerationSchema
+});
+
+export const PreviewIndexSchema = z.object({
+	generatedAt: z.string().datetime(),
+	entries: z.array(PreviewIndexEntrySchema)
+});
+
+export type PreviewIndexEntry = z.infer<typeof PreviewIndexEntrySchema>;
+export type PreviewDetail = z.infer<typeof PreviewDetailSchema>;
+export type PreviewIndex = z.infer<typeof PreviewIndexSchema>;

--- a/web/src/routes/admin/previews/+page.svelte
+++ b/web/src/routes/admin/previews/+page.svelte
@@ -1,0 +1,216 @@
+<script lang="ts">
+	import * as Card from '$lib/components/ui/card/index.js';
+	import { cn } from '$lib/utils.js';
+	import type { PreviewDetail } from '$lib/types/adminPreview';
+	import type { PageData } from './$types';
+
+	let { data }: { data: PageData } = $props();
+
+	let selectedId = $state(data.entries[0]?.id ?? null);
+	const selectedEntry = $derived(
+		selectedId === null ? null : (data.entries.find((entry) => entry.id === selectedId) ?? null)
+	);
+
+	const formattedGeneratedAt = $derived(formatGeneratedAt(data.generatedAt));
+
+	function formatGeneratedAt(value: string): string {
+		const timestamp = new Date(value);
+		if (Number.isNaN(timestamp.getTime())) {
+			return value;
+		}
+		return new Intl.DateTimeFormat('en-GB', {
+			dateStyle: 'long',
+			timeStyle: 'short'
+		}).format(timestamp);
+	}
+
+	function formatQuestionType(value: string): string {
+		return value.replace(/_/g, ' ');
+	}
+
+	function formatOptional(value: string | undefined | null): string {
+		if (!value) {
+			return '—';
+		}
+		const trimmed = value.trim();
+		return trimmed.length > 0 ? trimmed : '—';
+	}
+
+	function handleSelect(entry: PreviewDetail): void {
+		selectedId = entry.id;
+	}
+</script>
+
+<svelte:head>
+	<title>Admin · Quiz Generation Previews</title>
+</svelte:head>
+
+<div class="space-y-6">
+	<div class="flex flex-wrap items-center justify-between gap-3">
+		<div>
+			<h1 class="text-2xl font-semibold tracking-tight">Quiz Generation Previews</h1>
+			<p class="text-sm text-muted-foreground">
+				Review static quiz outputs generated from the current sample files.
+			</p>
+		</div>
+		<div
+			class="rounded-md border border-border bg-muted/50 px-3 py-2 text-xs text-muted-foreground"
+		>
+			Last generated
+			<span class="font-medium text-foreground">{formattedGeneratedAt}</span>
+		</div>
+	</div>
+
+	{#if data.entries.length === 0}
+		<Card.Root>
+			<Card.Content class="py-12 text-center text-sm text-muted-foreground">
+				No preview data is available. Run <code>npm run generate:admin-previews</code> to create it.
+			</Card.Content>
+		</Card.Root>
+	{:else}
+		<div class="grid gap-4 lg:grid-cols-[320px,1fr]">
+			<Card.Root class="h-full">
+				<Card.Header>
+					<Card.Title>Sample files</Card.Title>
+					<Card.Description>Choose a source file to inspect the generated quiz.</Card.Description>
+				</Card.Header>
+				<Card.Content class="space-y-2">
+					<ul class="flex flex-col gap-2">
+						{#each data.entries as entry (entry.id)}
+							<li>
+								<button
+									type="button"
+									class={cn(
+										'w-full rounded-lg border px-3 py-2 text-left text-sm transition focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-none',
+										selectedEntry?.id === entry.id
+											? 'border-primary bg-primary/10 text-primary'
+											: 'border-transparent hover:border-border hover:bg-muted'
+									)}
+									onclick={() => handleSelect(entry)}
+								>
+									<div class="flex flex-col gap-1">
+										<span class="font-medium">
+											#{entry.id.toString().padStart(2, '0')} · {entry.sourceRelativePath}
+										</span>
+										<span class="text-xs text-muted-foreground">
+											{entry.mode} · {entry.questionCount} questions
+										</span>
+									</div>
+								</button>
+							</li>
+						{/each}
+					</ul>
+				</Card.Content>
+			</Card.Root>
+
+			<Card.Root class="h-full">
+				{#if selectedEntry}
+					<Card.Header>
+						<Card.Title>File #{selectedEntry.id.toString().padStart(2, '0')}</Card.Title>
+						<Card.Description class="break-words">
+							{selectedEntry.sourceRelativePath}
+						</Card.Description>
+					</Card.Header>
+					<Card.Content class="space-y-6">
+						<div class="grid gap-4 text-sm md:grid-cols-2">
+							<div class="space-y-1">
+								<p class="text-xs text-muted-foreground uppercase">Mode</p>
+								<p class="font-medium capitalize">{selectedEntry.mode}</p>
+							</div>
+							<div class="space-y-1">
+								<p class="text-xs text-muted-foreground uppercase">Questions</p>
+								<p class="font-medium">{selectedEntry.questionCount}</p>
+							</div>
+							<div class="space-y-1">
+								<p class="text-xs text-muted-foreground uppercase">Subject</p>
+								<p class="font-medium">{formatOptional(selectedEntry.subject)}</p>
+							</div>
+							<div class="space-y-1">
+								<p class="text-xs text-muted-foreground uppercase">Board</p>
+								<p class="font-medium">{formatOptional(selectedEntry.board)}</p>
+							</div>
+						</div>
+
+						<div class="space-y-2">
+							<h2 class="text-base font-semibold">Quiz summary</h2>
+							<p class="text-sm leading-relaxed text-muted-foreground">
+								{selectedEntry.quiz.summary}
+							</p>
+						</div>
+
+						<div class="space-y-4">
+							<h2 class="text-base font-semibold">Questions</h2>
+							{#each selectedEntry.quiz.questions as question, index (question.id)}
+								<div class="rounded-lg border border-border bg-card/80 p-4 shadow-sm">
+									<div class="flex flex-wrap items-start justify-between gap-2">
+										<div class="text-sm font-semibold">
+											Question {index + 1}
+										</div>
+										<div class="text-xs tracking-wide text-muted-foreground uppercase">
+											{formatQuestionType(question.type)}
+										</div>
+									</div>
+									<p class="mt-3 text-sm leading-relaxed font-medium">
+										{question.prompt}
+									</p>
+									{#if question.type === 'multiple_choice' && question.options}
+										<ul class="mt-3 space-y-1 text-sm text-muted-foreground">
+											{#each question.options as option, optionIndex (optionIndex)}
+												<li>
+													<span class="font-semibold text-foreground">
+														{String.fromCharCode(65 + optionIndex)}.
+													</span>
+													<span class="ml-2">{option}</span>
+												</li>
+											{/each}
+										</ul>
+									{/if}
+									<div class="mt-3 space-y-2 text-sm text-muted-foreground">
+										<p>
+											<span class="font-semibold text-foreground">Answer:</span>
+											<span class="ml-2">{question.answer}</span>
+										</p>
+										<p>
+											<span class="font-semibold text-foreground">Explanation:</span>
+											<span class="ml-2">{question.explanation}</span>
+										</p>
+										{#if question.topic}
+											<p>
+												<span class="font-semibold text-foreground">Topic:</span>
+												<span class="ml-2">{question.topic}</span>
+											</p>
+										{/if}
+										{#if question.difficulty}
+											<p>
+												<span class="font-semibold text-foreground">Difficulty:</span>
+												<span class="ml-2 capitalize">{question.difficulty}</span>
+											</p>
+										{/if}
+										{#if question.skillFocus}
+											<p>
+												<span class="font-semibold text-foreground">Skill focus:</span>
+												<span class="ml-2">{question.skillFocus}</span>
+											</p>
+										{/if}
+										{#if question.sourceReference}
+											<p>
+												<span class="font-semibold text-foreground">Source:</span>
+												<span class="ml-2">{question.sourceReference}</span>
+											</p>
+										{/if}
+									</div>
+								</div>
+							{/each}
+						</div>
+					</Card.Content>
+				{:else}
+					<Card.Content
+						class="flex h-full items-center justify-center text-sm text-muted-foreground"
+					>
+						Select a sample to view its generated quiz.
+					</Card.Content>
+				{/if}
+			</Card.Root>
+		</div>
+	{/if}
+</div>

--- a/web/src/routes/admin/previews/+page.ts
+++ b/web/src/routes/admin/previews/+page.ts
@@ -1,0 +1,35 @@
+import { error } from '@sveltejs/kit';
+
+import { PreviewDetailSchema, PreviewIndexSchema } from '$lib/types/adminPreview';
+import type { PageLoad } from './$types';
+
+const STATIC_INDEX_PATH = '/admin-preview-data/index.json';
+const STATIC_ENTRY_PREFIX = '/admin-preview-data/';
+
+export const load = (async ({ fetch }) => {
+	const indexResponse = await fetch(STATIC_INDEX_PATH, { cache: 'no-store' });
+	if (!indexResponse.ok) {
+		throw error(indexResponse.status, 'Failed to load admin preview index.');
+	}
+
+	const indexJson = await indexResponse.json();
+	const index = PreviewIndexSchema.parse(indexJson);
+
+	const entries = [];
+	for (const entry of index.entries) {
+		const detailResponse = await fetch(`${STATIC_ENTRY_PREFIX}${entry.outputFile}`, {
+			cache: 'no-store'
+		});
+		if (!detailResponse.ok) {
+			throw error(detailResponse.status, `Failed to load preview details for ${entry.outputFile}.`);
+		}
+		const detailJson = await detailResponse.json();
+		const detail = PreviewDetailSchema.parse(detailJson);
+		entries.push(detail);
+	}
+
+	return {
+		generatedAt: index.generatedAt,
+		entries
+	};
+}) satisfies PageLoad;

--- a/web/static/admin-preview-data/index.json
+++ b/web/static/admin-preview-data/index.json
@@ -1,0 +1,50 @@
+{
+  "generatedAt": "2025-09-22T08:19:33.236Z",
+  "entries": [
+    {
+      "id": 1,
+      "sourceRelativePath": "no-questions/Y8Lesson-Health-BloodDonations.pdf",
+      "mode": "synthesis",
+      "subject": "biology",
+      "board": "OCR",
+      "questionCount": 6,
+      "outputFile": "preview-01.json"
+    },
+    {
+      "id": 2,
+      "sourceRelativePath": "with-questions/18FCF3EB-957A-4922-86C8-28CF0F1CA467_1_105_c.jpeg",
+      "mode": "extraction",
+      "subject": "chemistry",
+      "board": "AQA",
+      "questionCount": 6,
+      "outputFile": "preview-02.json"
+    },
+    {
+      "id": 3,
+      "sourceRelativePath": "with-questions/966860A9-BFD8-436C-958D-2470ED154DA6_1_105_c.jpeg",
+      "mode": "extraction",
+      "subject": "chemistry",
+      "board": "AQA",
+      "questionCount": 6,
+      "outputFile": "preview-03.json"
+    },
+    {
+      "id": 4,
+      "sourceRelativePath": "with-questions/C2.1ExamQs.pdf",
+      "mode": "extraction",
+      "subject": "chemistry",
+      "board": "AQA",
+      "questionCount": 6,
+      "outputFile": "preview-04.json"
+    },
+    {
+      "id": 5,
+      "sourceRelativePath": "with-questions/F503558B-56E2-4FB4-B7C9-788A6231BBA3_1_105_c.jpeg",
+      "mode": "extraction",
+      "subject": "chemistry",
+      "board": "AQA",
+      "questionCount": 6,
+      "outputFile": "preview-05.json"
+    }
+  ]
+}

--- a/web/static/admin-preview-data/preview-01.json
+++ b/web/static/admin-preview-data/preview-01.json
@@ -1,0 +1,97 @@
+{
+  "id": 1,
+  "sourceRelativePath": "no-questions/Y8Lesson-Health-BloodDonations.pdf",
+  "mode": "synthesis",
+  "subject": "biology",
+  "board": "OCR",
+  "questionCount": 6,
+  "outputFile": "preview-01.json",
+  "quiz": {
+    "quizTitle": "GCSE Biology: Blood and Organ Donation",
+    "summary": "This quiz covers the importance of blood, organ, and stem cell donation, the types of individuals who might need these donations, the processes involved in becoming a donor, and the legal framework surrounding organ donation in England. It includes a mix of multiple-choice, short-answer, true/false, and numeric questions to assess understanding of key concepts. The material provided did not contain explicit details for 'syllabusAlignment', so this field has been omitted.",
+    "mode": "synthesis",
+    "subject": "biology",
+    "board": "OCR",
+    "questionCount": 6,
+    "questions": [
+      {
+        "id": "q1",
+        "prompt": "According to the provided information, approximately how many new blood donors are needed every day in England to meet demand?",
+        "answer": "D",
+        "explanation": "Slide 6 states: \"Nearly 400 new blood donors are needed every day in England to meet demand.\"",
+        "type": "multiple_choice",
+        "options": [
+          "A. 100",
+          "B. 200",
+          "C. 300",
+          "D. 400"
+        ],
+        "topic": "Importance of blood donation",
+        "difficulty": "foundation",
+        "skillFocus": "Recall",
+        "sourceReference": "OCR for page 6"
+      },
+      {
+        "id": "q2",
+        "prompt": "Identify two types of conditions or situations that would lead someone to require a stem cell donation.",
+        "answer": "Someone with blood cancer or a blood disorder.",
+        "explanation": "Slide 5 clearly states that \"Someone with blood cancer or a blood disorder\" might need a stem cell donation.",
+        "type": "short_answer",
+        "topic": "Recipients of stem cell donation",
+        "difficulty": "foundation",
+        "skillFocus": "Identification",
+        "sourceReference": "OCR for page 5"
+      },
+      {
+        "id": "q3",
+        "prompt": "True or False: From 2020, anyone over 18 in England is automatically considered an organ donor upon death, regardless of whether they have registered a decision.",
+        "answer": "False",
+        "explanation": "Slide 13 states: \"From 2020, anyone over 18 in England will be considered an organ donor when they die unless they have registered a decision not to donate or are in an excluded group\". This means they are not automatically considered a donor if they have opted out.",
+        "type": "true_false",
+        "topic": "Organ donation law",
+        "difficulty": "intermediate",
+        "skillFocus": "Understanding legal frameworks",
+        "sourceReference": "OCR for page 13"
+      },
+      {
+        "id": "q4",
+        "prompt": "How many adults can a single blood donation help, according to the information provided?",
+        "answer": "3",
+        "explanation": "Slide 8 explains that after a donor's blood is split into component parts, \"each donation can help 3 adults or 6 infants.\"",
+        "type": "numeric",
+        "topic": "Impact of blood donation",
+        "difficulty": "foundation",
+        "skillFocus": "Data extraction",
+        "sourceReference": "OCR for page 8"
+      },
+      {
+        "id": "q5",
+        "prompt": "Which of the following is the most common method for donating stem cells, as described in the provided material?",
+        "answer": "B",
+        "explanation": "Slide 10 states that \"Stem cells can be donated in one of two ways: • through the bloodstream (90% of donors) • bone marrow donation procedure (10% of donors)\". Therefore, through the bloodstream is the most common method.",
+        "type": "multiple_choice",
+        "options": [
+          "A. Through a surgical procedure",
+          "B. Through the bloodstream",
+          "C. Directly from bone marrow",
+          "D. Via a cheek swab"
+        ],
+        "topic": "Stem cell donation process",
+        "difficulty": "intermediate",
+        "skillFocus": "Data interpretation",
+        "sourceReference": "OCR for page 10"
+      },
+      {
+        "id": "q6",
+        "prompt": "Explain two distinct reasons why an individual might choose not to donate blood or organs, based on the provided material.",
+        "answer": "An individual might choose not to donate blood due to a fear of needles. They might also choose not to donate organs because they feel uncomfortable with the idea of their organs being used after death, leading them to opt out on the NHS Organ Donation Register.",
+        "explanation": "Slide 16 provides two speech bubbles illustrating reasons for not donating: \"I'm really scared of needles, so giving blood isn't something I feel I'm able to do.\" and \"I feel uncomfortable with the idea of my organs being used after I die, so I recorded my decision to opt out of organ donation on the NHS Organ Donation Register.\"",
+        "type": "short_answer",
+        "topic": "Considerations for individual choice to donate",
+        "difficulty": "higher",
+        "skillFocus": "Analysis and synthesis of reasons",
+        "sourceReference": "OCR for page 16"
+      }
+    ]
+  }
+}

--- a/web/static/admin-preview-data/preview-02.json
+++ b/web/static/admin-preview-data/preview-02.json
@@ -1,0 +1,98 @@
+{
+  "id": 2,
+  "sourceRelativePath": "with-questions/18FCF3EB-957A-4922-86C8-28CF0F1CA467_1_105_c.jpeg",
+  "mode": "extraction",
+  "subject": "chemistry",
+  "board": "AQA",
+  "questionCount": 6,
+  "outputFile": "preview-02.json",
+  "quiz": {
+    "quizTitle": "GCSE Chemistry C1 Atomic Structure and Mixtures Quiz",
+    "summary": "This quiz covers fundamental concepts in GCSE Chemistry C1, focusing on atomic structure, historical atomic models, subatomic particles, electron configuration, and methods for separating mixtures. It includes a mix of recall-based short answer questions and multiple-choice questions, aligning with AQA GCSE Triple Science Chemistry specification requirements. The difficulty ranges from foundation to higher, ensuring comprehensive coverage of core topics.",
+    "mode": "extraction",
+    "subject": "chemistry",
+    "board": "AQA",
+    "syllabusAlignment": "AQA GCSE Triple Science Chemistry, Paper 1: Atomic Structure and the Periodic Table; Chemical Changes; Energy Changes; Rate and Extent of Chemical Change; Organic Chemistry; Chemical Analysis; Chemistry of the Atmosphere; Using Resources.",
+    "questionCount": 6,
+    "questions": [
+      {
+        "id": "Q1",
+        "prompt": "What is an atom?",
+        "answer": "The smallest part of an element that can exist.",
+        "explanation": "An atom is the fundamental building block of matter, defined as the smallest particle of an element that can exist while retaining the chemical identity of that element.",
+        "type": "short_answer",
+        "topic": "Atomic Structure",
+        "difficulty": "foundation",
+        "skillFocus": "Recall",
+        "sourceReference": "C1 questions, Q1"
+      },
+      {
+        "id": "Q2",
+        "prompt": "Which of the following best describes the plum pudding model of the atom?",
+        "answer": "A sphere of positive charge with negative electrons embedded in it.",
+        "explanation": "The plum pudding model, proposed by J.J. Thomson, depicted the atom as a sphere of uniformly distributed positive charge with negatively charged electrons embedded within it, much like plums in a pudding.",
+        "type": "multiple_choice",
+        "options": [
+          "A sphere of positive charge with negative electrons embedded in it.",
+          "Atoms as solid spheres that could not be divided into smaller parts.",
+          "A dense nucleus with electrons orbiting it in fixed energy levels.",
+          "A central nucleus containing protons and neutrons, with electrons in shells."
+        ],
+        "topic": "Atomic Models",
+        "difficulty": "intermediate",
+        "skillFocus": "Recall, Understanding",
+        "sourceReference": "C1 questions, Q3"
+      },
+      {
+        "id": "Q3",
+        "prompt": "What did James Chadwick discover?",
+        "answer": "An uncharged particle called the neutron.",
+        "explanation": "James Chadwick discovered the neutron in 1932, an uncharged subatomic particle found in the nucleus of an atom, which helped to explain the mass of atoms.",
+        "type": "short_answer",
+        "topic": "Subatomic Particles, Atomic Models",
+        "difficulty": "foundation",
+        "skillFocus": "Recall",
+        "sourceReference": "C1 questions, Q7"
+      },
+      {
+        "id": "Q4",
+        "prompt": "State the relative charge of a proton, a neutron, and an electron.",
+        "answer": "Proton: +1, Neutron: 0, Electron: -1.",
+        "explanation": "Protons carry a relative charge of +1, electrons carry a relative charge of -1, and neutrons are electrically neutral with a relative charge of 0.",
+        "type": "short_answer",
+        "topic": "Subatomic Particles",
+        "difficulty": "intermediate",
+        "skillFocus": "Recall",
+        "sourceReference": "C1 questions, Q10"
+      },
+      {
+        "id": "Q5",
+        "prompt": "According to the shell model, how many electrons can occupy the first, second, and third electron shells?",
+        "answer": "Up to 2 in the first shell, and up to 8 in the second and third shells.",
+        "explanation": "For stable atoms, the first electron shell can hold a maximum of 2 electrons, while the second and third shells can each hold up to 8 electrons.",
+        "type": "short_answer",
+        "topic": "Electron Configuration",
+        "difficulty": "intermediate",
+        "skillFocus": "Recall",
+        "sourceReference": "C1 questions, Q14"
+      },
+      {
+        "id": "Q6",
+        "prompt": "Which of the following lists four physical processes used to separate mixtures?",
+        "answer": "Filtration, crystallisation, distillation, chromatography.",
+        "explanation": "Filtration separates insoluble solids from liquids, crystallisation separates soluble solids from solutions, distillation separates liquids with different boiling points, and chromatography separates substances based on their differential partitioning between a stationary and mobile phase.",
+        "type": "multiple_choice",
+        "options": [
+          "Filtration, crystallisation, distillation, chromatography.",
+          "Combustion, neutralisation, electrolysis, precipitation.",
+          "Melting, boiling, freezing, condensation.",
+          "Oxidation, reduction, displacement, decomposition."
+        ],
+        "topic": "Separating Mixtures",
+        "difficulty": "higher",
+        "skillFocus": "Recall, Application",
+        "sourceReference": "C1 questions, Q19"
+      }
+    ]
+  }
+}

--- a/web/static/admin-preview-data/preview-03.json
+++ b/web/static/admin-preview-data/preview-03.json
@@ -1,0 +1,104 @@
+{
+  "id": 3,
+  "sourceRelativePath": "with-questions/966860A9-BFD8-436C-958D-2470ED154DA6_1_105_c.jpeg",
+  "mode": "extraction",
+  "subject": "chemistry",
+  "board": "AQA",
+  "questionCount": 6,
+  "outputFile": "preview-03.json",
+  "quiz": {
+    "quizTitle": "GCSE Chemistry C2 Covalent Bonding Retrieval Quiz",
+    "summary": "This quiz covers fundamental concepts of covalent bonding, including the formation and properties of different covalent structures such as giant covalent substances, small molecules, and allotropes of carbon like graphite and fullerenes. It includes a mix of multiple-choice and short-answer questions designed to test recall and understanding of key definitions and explanations.",
+    "mode": "extraction",
+    "subject": "chemistry",
+    "board": "AQA",
+    "syllabusAlignment": "AQA GCSE Chemistry C2: Structure, bonding and the properties of matter (Covalent bonding)",
+    "questionCount": 6,
+    "questions": [
+      {
+        "id": "Q1_CB_001",
+        "prompt": "How are covalent bonds formed?",
+        "answer": "by atoms sharing electrons",
+        "explanation": "Covalent bonds are formed when atoms share pairs of electrons to achieve a stable outer shell, typically between non-metal atoms.",
+        "type": "multiple_choice",
+        "options": [
+          "A: by atoms transferring electrons",
+          "B: by atoms sharing electrons",
+          "C: by atoms gaining electrons",
+          "D: by atoms losing electrons"
+        ],
+        "topic": "Covalent bond formation",
+        "difficulty": "foundation",
+        "skillFocus": "Recall",
+        "sourceReference": "C2 questions, Q1"
+      },
+      {
+        "id": "Q1_CB_002",
+        "prompt": "Which type of atoms typically form covalent bonds between them?",
+        "answer": "non-metals",
+        "explanation": "Covalent bonds are typically formed between two non-metal atoms, where both atoms need to gain electrons to complete their outer shell.",
+        "type": "multiple_choice",
+        "options": [
+          "A: metals and non-metals",
+          "B: metals",
+          "C: non-metals",
+          "D: noble gases"
+        ],
+        "topic": "Covalent bond formation",
+        "difficulty": "foundation",
+        "skillFocus": "Recall",
+        "sourceReference": "C2 questions, Q2"
+      },
+      {
+        "id": "Q1_CB_003",
+        "prompt": "Explain why giant covalent substances have high melting points.",
+        "answer": "It takes a lot of energy to break the strong covalent bonds between the atoms.",
+        "explanation": "Giant covalent structures consist of billions of atoms held together by a vast network of strong covalent bonds. A significant amount of thermal energy is required to overcome these strong bonds, leading to high melting and boiling points.",
+        "type": "short_answer",
+        "topic": "Properties of giant covalent structures",
+        "difficulty": "intermediate",
+        "skillFocus": "Explanation, Reasoning",
+        "sourceReference": "C2 questions, Q6"
+      },
+      {
+        "id": "Q1_CB_004",
+        "prompt": "Describe the structure and bonding in graphite.",
+        "answer": "Each carbon atom is bonded to three others in hexagonal rings arranged in layers. It has delocalised electrons and weak forces between the layers.",
+        "explanation": "In graphite, each carbon atom forms three covalent bonds with other carbon atoms, creating hexagonal rings arranged in layers. There are delocalised electrons between the layers, and weak intermolecular forces hold the layers together.",
+        "type": "short_answer",
+        "topic": "Structure of graphite",
+        "difficulty": "intermediate",
+        "skillFocus": "Description",
+        "sourceReference": "C2 questions, Q10"
+      },
+      {
+        "id": "Q1_CB_005",
+        "prompt": "Why can graphite conduct electricity?",
+        "answer": "The delocalised electrons can move through the graphite.",
+        "explanation": "Unlike diamond, graphite has one valence electron from each carbon atom that is not involved in covalent bonding. These electrons become delocalised and are free to move throughout the layers, allowing graphite to conduct electricity.",
+        "type": "short_answer",
+        "topic": "Properties of graphite",
+        "difficulty": "intermediate",
+        "skillFocus": "Explanation, Reasoning",
+        "sourceReference": "C2 questions, Q11"
+      },
+      {
+        "id": "Q1_CB_006",
+        "prompt": "What is a fullerene?",
+        "answer": "hollow cage of carbon atoms arranged as a sphere or a tube",
+        "explanation": "Fullerenes are a class of carbon allotropes consisting of hollow molecular cages or tubes, where carbon atoms are arranged in pentagonal and hexagonal rings.",
+        "type": "multiple_choice",
+        "options": [
+          "A: a giant lattice of carbon atoms",
+          "B: a single layer of carbon atoms in a hexagonal lattice",
+          "C: hollow cage of carbon atoms arranged as a sphere or a tube",
+          "D: carbon atoms bonded in a tetrahedral arrangement"
+        ],
+        "topic": "Allotropes of carbon (Fullerenes)",
+        "difficulty": "foundation",
+        "skillFocus": "Recall, Definition",
+        "sourceReference": "C2 questions, Q15"
+      }
+    ]
+  }
+}

--- a/web/static/admin-preview-data/preview-04.json
+++ b/web/static/admin-preview-data/preview-04.json
@@ -1,0 +1,104 @@
+{
+  "id": 4,
+  "sourceRelativePath": "with-questions/C2.1ExamQs.pdf",
+  "mode": "extraction",
+  "subject": "chemistry",
+  "board": "AQA",
+  "questionCount": 6,
+  "outputFile": "preview-04.json",
+  "quiz": {
+    "quizTitle": "States of Matter and Chemical Reactions Quiz",
+    "summary": "This quiz covers fundamental concepts in AQA GCSE Chemistry, focusing on states of matter, chemical equations, and the particle model. It includes questions on interpreting graphical data for melting and boiling points, applying knowledge of state symbols in chemical reactions, and understanding the characteristics of particles in different states. The question mix includes short answer and multiple-choice questions, testing both recall and data interpretation skills across foundation, intermediate, and higher difficulty levels.",
+    "mode": "extraction",
+    "subject": "chemistry",
+    "board": "AQA",
+    "syllabusAlignment": "AQA GCSE Chemistry: States of Matter, Chemical Changes (writing equations and state symbols), and the Particle Model.",
+    "questionCount": 6,
+    "questions": [
+      {
+        "id": "Q1a",
+        "prompt": "Lithium reacts with water to produce lithium hydroxide solution and hydrogen. Use the correct state symbols from the box (aq, g, l, s) to complete the chemical equation: 2Li(s) + 2H2O(l) → 2LiOH(__) + H2(__)",
+        "answer": "aq, g",
+        "explanation": "Lithium hydroxide is formed as a solution in water, hence 'aq' (aqueous). Hydrogen is a gas, hence 'g'.",
+        "type": "short_answer",
+        "topic": "Chemical equations and state symbols",
+        "difficulty": "foundation",
+        "skillFocus": "Application of knowledge",
+        "sourceReference": "Page 1, Question 1(a)"
+      },
+      {
+        "id": "Q1b",
+        "prompt": "Figure 1 shows the melting points (x) and the boiling points (•) of four substances, A, B, C and D. Which substance is liquid over the greatest temperature range?",
+        "answer": "C",
+        "explanation": "From Figure 1: Substance A is liquid from approx. -100°C to 0°C (range 100°C). Substance B is liquid from approx. 70°C to 190°C (range 120°C). Substance C is liquid from approx. 10°C to 190°C (range 180°C). Substance D is liquid from approx. -180°C to -120°C (range 60°C). Therefore, substance C has the greatest liquid temperature range.",
+        "type": "multiple_choice",
+        "options": [
+          "A",
+          "B",
+          "C",
+          "D"
+        ],
+        "topic": "States of matter, melting and boiling points",
+        "difficulty": "intermediate",
+        "skillFocus": "Data interpretation",
+        "sourceReference": "Page 2, Question 1(b), Figure 1"
+      },
+      {
+        "id": "Q1c",
+        "prompt": "Figure 1 shows the melting points (x) and the boiling points (•) of four substances, A, B, C and D. Which two substances are gases at 50 °C?",
+        "answer": "A and D",
+        "explanation": "At 50°C: Substance A has a boiling point of 0°C, so it is a gas. Substance B has a boiling point of 190°C, so it is a liquid. Substance C has a boiling point of 190°C, so it is a liquid. Substance D has a boiling point of -120°C, so it is a gas. Therefore, A and D are gases at 50°C.",
+        "type": "multiple_choice",
+        "options": [
+          "A and B",
+          "B and C",
+          "C and D",
+          "A and D"
+        ],
+        "topic": "States of matter, temperature effects",
+        "difficulty": "intermediate",
+        "skillFocus": "Data interpretation",
+        "sourceReference": "Page 3, Question 1(c), Figure 1"
+      },
+      {
+        "id": "Q1e",
+        "prompt": "Figure 2 shows the apparatus a student used to determine the melting point and the boiling point of substance B. Explain why the student could not use this apparatus to determine the boiling point of substance B.",
+        "answer": "The apparatus shown uses a water bath. Water boils at 100°C. From Figure 1, substance B has a boiling point of approximately 190°C, which is much higher than the boiling point of water. Therefore, the water bath cannot reach the temperature required to boil substance B.",
+        "explanation": "A water bath can only heat substances up to 100°C (the boiling point of water). Substance B has a boiling point of approximately 190°C, which is significantly higher than 100°C. Thus, the water bath cannot provide enough heat to reach the boiling point of substance B.",
+        "type": "short_answer",
+        "topic": "Experimental techniques, heating methods",
+        "difficulty": "higher",
+        "skillFocus": "Scientific reasoning, experimental design",
+        "sourceReference": "Page 4, Question 1(e), Figure 2"
+      },
+      {
+        "id": "Q2a",
+        "prompt": "A student shakes a tube containing small balls to model the movement of particles in a gas. Why is this a good model for the movement of particles in a gas? Select the option that includes two correct reasons.",
+        "answer": "The balls are far apart from each other and move randomly.",
+        "explanation": "In a gas, particles are widely spaced (far apart) and move randomly and rapidly. The model accurately represents these two key characteristics.",
+        "type": "multiple_choice",
+        "options": [
+          "The balls move slowly and are far apart from each other.",
+          "The balls are far apart from each other and move randomly.",
+          "The balls are different colours and move slowly.",
+          "The balls move randomly and are different colours."
+        ],
+        "topic": "Particle model of matter, gases",
+        "difficulty": "foundation",
+        "skillFocus": "Conceptual understanding",
+        "sourceReference": "Page 5, Question 2(a)"
+      },
+      {
+        "id": "Q2b",
+        "prompt": "For a given material, in which state of matter: 1. are the particles in a regular arrangement? 2. do the particles have the most kinetic energy?",
+        "answer": "1. Solid. 2. Gas.",
+        "explanation": "Particles in a solid are arranged in a fixed, regular pattern. Particles in a gas have the highest kinetic energy because they move randomly and rapidly, colliding with each other and the container walls.",
+        "type": "short_answer",
+        "topic": "States of matter, particle arrangement, kinetic energy",
+        "difficulty": "foundation",
+        "skillFocus": "Recall of facts",
+        "sourceReference": "Page 5, Question 2(b)"
+      }
+    ]
+  }
+}

--- a/web/static/admin-preview-data/preview-05.json
+++ b/web/static/admin-preview-data/preview-05.json
@@ -1,0 +1,98 @@
+{
+  "id": 5,
+  "sourceRelativePath": "with-questions/F503558B-56E2-4FB4-B7C9-788A6231BBA3_1_105_c.jpeg",
+  "mode": "extraction",
+  "subject": "chemistry",
+  "board": "AQA",
+  "questionCount": 6,
+  "outputFile": "preview-05.json",
+  "quiz": {
+    "quizTitle": "GCSE Triple Science Chemistry Retrieval Quiz: C20 Topics",
+    "summary": "This GCSE Triple Science Chemistry quiz, aligned with the AQA specification, covers key topics including corrosion, alloys, polymers, the Haber process, and NPK fertilisers. It features a mix of 2 multiple-choice and 4 short-answer questions designed to test recall, understanding, and application of chemical principles. Questions range in difficulty from foundation to higher, providing a comprehensive review. Note: One factual correction was made to the balanced equation for the Haber process (Q4) to ensure accuracy for exam readiness.",
+    "mode": "extraction",
+    "subject": "chemistry",
+    "board": "AQA",
+    "syllabusAlignment": "AQA GCSE Chemistry (8462) and Combined Science: Trilogy (8464) specifications, covering topics such as 'The Earth's resources' and 'Chemical changes'.",
+    "questionCount": 6,
+    "questions": [
+      {
+        "id": "Q1",
+        "prompt": "What is corrosion?",
+        "answer": "A",
+        "explanation": "Corrosion is defined as the destruction of materials, typically metals, by chemical reactions with their environment, often involving oxygen and water.",
+        "type": "multiple_choice",
+        "options": [
+          "A: The destruction of a material through reactions with substances in the environment.",
+          "B: The process of a metal gaining electrons.",
+          "C: The formation of a protective oxide layer on a metal surface.",
+          "D: The reaction of a metal with an acid to produce hydrogen gas."
+        ],
+        "topic": "Corrosion",
+        "difficulty": "foundation",
+        "skillFocus": "Recall, Definition",
+        "sourceReference": "C20 questions, Q1"
+      },
+      {
+        "id": "Q2",
+        "prompt": "Name two alloys of copper.",
+        "answer": "Brass and bronze",
+        "explanation": "Brass is an alloy primarily composed of copper and zinc, while bronze is an alloy primarily composed of copper and tin. Both are common and important copper alloys.",
+        "type": "short_answer",
+        "topic": "Alloys",
+        "difficulty": "foundation",
+        "skillFocus": "Recall",
+        "sourceReference": "C20 questions, Q5"
+      },
+      {
+        "id": "Q3",
+        "prompt": "Which statement accurately describes the main difference between thermosetting and thermosoftening polymers?",
+        "answer": "B",
+        "explanation": "Thermosetting polymers form permanent cross-links between polymer chains when heated, making them rigid and preventing them from softening or melting upon subsequent heating. Thermosoftening polymers have weaker intermolecular forces and can be melted and reshaped repeatedly.",
+        "type": "multiple_choice",
+        "options": [
+          "A: Thermosoftening polymers are formed from monomers, while thermosetting polymers are not.",
+          "B: Thermosetting polymers do not soften when heated, whereas thermosoftening polymers do.",
+          "C: Thermosetting polymers have weak intermolecular forces, while thermosoftening polymers have strong covalent bonds.",
+          "D: Thermosoftening polymers are always recyclable, but thermosetting polymers are never recyclable."
+        ],
+        "topic": "Polymers",
+        "difficulty": "intermediate",
+        "skillFocus": "Compare and Contrast",
+        "sourceReference": "C20 questions, Q12"
+      },
+      {
+        "id": "Q4",
+        "prompt": "Write the balanced symbol equation for the Haber process.",
+        "answer": "N₂(g) + 3H₂(g) = 2NH₃(g)",
+        "explanation": "The Haber process combines nitrogen gas (N₂) from the air with hydrogen gas (H₂) to produce ammonia (NH₃). The equation must be balanced to show the conservation of atoms: one molecule of nitrogen reacts with three molecules of hydrogen to produce two molecules of ammonia.",
+        "type": "short_answer",
+        "topic": "Haber Process, Industrial Chemistry",
+        "difficulty": "higher",
+        "skillFocus": "Application, Equation Balancing",
+        "sourceReference": "C20 questions, Q15"
+      },
+      {
+        "id": "Q5",
+        "prompt": "Describe the effect of increasing the pressure of the Haber process on the yield, rate, and cost.",
+        "answer": "Increasing the pressure increases the yield of ammonia, increases the rate of reaction, and increases the cost of the plant and operation.",
+        "explanation": "According to Le Chatelier's principle, increasing pressure shifts the equilibrium towards the side with fewer gas moles (the product side for the Haber process), thus increasing the yield of ammonia. Higher pressure also increases the frequency of collisions between reactant particles, leading to an increased reaction rate. However, building and maintaining high-pressure equipment is more expensive, increasing overall costs.",
+        "type": "short_answer",
+        "topic": "Haber Process, Industrial Chemistry, Le Chatelier's Principle",
+        "difficulty": "higher",
+        "skillFocus": "Analysis, Evaluation",
+        "sourceReference": "C20 questions, Q18"
+      },
+      {
+        "id": "Q6",
+        "prompt": "What is an NPK fertiliser?",
+        "answer": "An NPK fertiliser is a formulation containing soluble compounds of nitrogen, phosphorus, and potassium.",
+        "explanation": "NPK stands for Nitrogen (N), Phosphorus (P), and Potassium (K), which are the three essential macronutrients required by plants for healthy growth. Fertilisers containing these elements in soluble forms are crucial for agriculture to replenish soil nutrients.",
+        "type": "short_answer",
+        "topic": "Fertilisers, Agriculture",
+        "difficulty": "intermediate",
+        "skillFocus": "Recall, Definition",
+        "sourceReference": "C20 questions, Q21"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add a `generate-admin-previews` npm script that runs a Gemini-backed CLI to render quiz JSON for every sample file and persist the outputs under `static/admin-preview-data`
- refactor the Gemini quiz generator prompts into a reusable `generationCore` module shared by both the CLI and runtime code, and update the admin sidebar navigation
- add a new `/admin/previews` page that loads the static JSON index, lets reviewers browse each generated quiz, and highlights per-question details

## Testing
- npm run generate:admin-previews
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d104a888d0832eaf7ed9df5295af3f