### PR TITLE
[fix/web] eliminate landing theme flash

### DIFF
--- a/web/src/app.css
+++ b/web/src/app.css
@@ -5,6 +5,7 @@
 @custom-variant dark (&:is(.dark *));
 
 :root {
+	color-scheme: light;
 	--radius: 0.625rem;
 	--background: oklch(1 0 0);
 	--foreground: oklch(0.129 0.042 264.695);
@@ -47,7 +48,53 @@
 	--sound-toggle-foreground: rgba(15, 23, 42, 0.82);
 }
 
+@media (prefers-color-scheme: dark) {
+	:root:not([data-theme='light']) {
+		color-scheme: dark;
+		--background: oklch(0.129 0.042 264.695);
+		--foreground: oklch(0.984 0.003 247.858);
+		--card: oklch(0.208 0.042 265.755);
+		--card-foreground: oklch(0.984 0.003 247.858);
+		--popover: oklch(0.208 0.042 265.755);
+		--popover-foreground: oklch(0.984 0.003 247.858);
+		--primary: oklch(0.929 0.013 255.508);
+		--primary-foreground: oklch(0.208 0.042 265.755);
+		--secondary: oklch(0.279 0.041 260.031);
+		--secondary-foreground: oklch(0.984 0.003 247.858);
+		--muted: oklch(0.279 0.041 260.031);
+		--muted-foreground: oklch(0.704 0.04 256.788);
+		--accent: oklch(0.279 0.041 260.031);
+		--accent-foreground: oklch(0.984 0.003 247.858);
+		--destructive: oklch(0.704 0.191 22.216);
+		--border: oklch(1 0 0 / 10%);
+		--input: oklch(1 0 0 / 15%);
+		--ring: oklch(0.551 0.027 264.364);
+		--chart-1: oklch(0.488 0.243 264.376);
+		--chart-2: oklch(0.696 0.17 162.48);
+		--chart-3: oklch(0.769 0.188 70.08);
+		--chart-4: oklch(0.627 0.265 303.9);
+		--chart-5: oklch(0.645 0.246 16.439);
+		--sidebar: oklch(0.208 0.042 265.755);
+		--sidebar-foreground: oklch(0.984 0.003 247.858);
+		--sidebar-primary: oklch(0.488 0.243 264.376);
+		--sidebar-primary-foreground: oklch(0.984 0.003 247.858);
+		--sidebar-accent: oklch(0.279 0.041 260.031);
+		--sidebar-accent-foreground: oklch(0.984 0.003 247.858);
+		--sidebar-border: oklch(1 0 0 / 10%);
+		--sidebar-ring: oklch(0.551 0.027 264.364);
+		--surface-color: var(--card);
+		--surface-border: var(--border);
+		--text-primary: var(--foreground);
+		--text-secondary: var(--muted-foreground);
+		--accent-contrast: var(--popover-foreground);
+		--shadow-color: rgba(2, 6, 23, 0.55);
+		--sound-toggle-bg: rgba(7, 18, 38, 0.6);
+		--sound-toggle-foreground: rgba(248, 250, 252, 0.88);
+	}
+}
+
 .dark {
+	color-scheme: dark;
 	--background: oklch(0.129 0.042 264.695);
 	--foreground: oklch(0.984 0.003 247.858);
 	--card: oklch(0.208 0.042 265.755);

--- a/web/src/app.html
+++ b/web/src/app.html
@@ -16,6 +16,7 @@
 				const theme = prefersDark ? 'dark' : 'light';
 				root.dataset.theme = theme;
 				root.classList.toggle('dark', theme === 'dark');
+				root.style.colorScheme = theme;
 			})();
 		</script>
 		%sveltekit.head%

--- a/web/src/lib/utils/theme.ts
+++ b/web/src/lib/utils/theme.ts
@@ -9,6 +9,7 @@ export function applyDocumentTheme(mode: ThemeMode): void {
 	const root = document.documentElement;
 	root.dataset.theme = mode;
 	root.classList.toggle('dark', mode === 'dark');
+	root.style.colorScheme = mode;
 }
 
 /**

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-
-	type Theme = 'light' | 'dark';
+	import { startAutomaticThemeSync } from '$lib/utils/theme';
 
 	let isMuted = true;
 	let shouldAutoPlay = true;
@@ -9,35 +8,11 @@
 	let videoEl: HTMLVideoElement | null = null;
 	const INTRO_POSTER = '/intro.jpg';
 
-	function applyTheme(next: Theme) {
-		if (typeof document === 'undefined') {
-			return;
-		}
-		const root = document.documentElement;
-		root.dataset.theme = next;
-		root.classList.toggle('dark', next === 'dark');
-	}
-
-	function setTheme(next: Theme) {
-		applyTheme(next);
-	}
-
-	if (typeof window !== 'undefined') {
-		const initialPreference = window.matchMedia('(prefers-color-scheme: dark)');
-		setTheme(initialPreference.matches ? 'dark' : 'light');
-	}
-
 	onMount(() => {
-		const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
+		const stopThemeSync = startAutomaticThemeSync();
 		const prefersReduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
 
 		shouldAutoPlay = !prefersReduceMotion.matches;
-
-		setTheme(prefersDark.matches ? 'dark' : 'light');
-
-		const handleThemeChange = (event: MediaQueryListEvent) => {
-			setTheme(event.matches ? 'dark' : 'light');
-		};
 
 		const handleMotionChange = (event: MediaQueryListEvent) => {
 			shouldAutoPlay = !event.matches;
@@ -46,11 +21,10 @@
 			}
 		};
 
-		prefersDark.addEventListener('change', handleThemeChange);
 		prefersReduceMotion.addEventListener('change', handleMotionChange);
 
 		return () => {
-			prefersDark.removeEventListener('change', handleThemeChange);
+			stopThemeSync();
 			prefersReduceMotion.removeEventListener('change', handleMotionChange);
 		};
 	});
@@ -244,8 +218,20 @@
 		background: radial-gradient(circle at 30% 40%, rgba(129, 140, 248, 0.42), transparent 70%);
 	}
 
+	@media (prefers-color-scheme: dark) {
+		.page::before {
+			background: radial-gradient(circle at 30% 40%, rgba(129, 140, 248, 0.42), transparent 70%);
+		}
+	}
+
 	:global([data-theme='dark'] .page::after) {
 		background: radial-gradient(circle at 60% 60%, rgba(56, 189, 248, 0.26), transparent 75%);
+	}
+
+	@media (prefers-color-scheme: dark) {
+		.page::after {
+			background: radial-gradient(circle at 60% 60%, rgba(56, 189, 248, 0.26), transparent 75%);
+		}
 	}
 
 	.top-bar {
@@ -322,6 +308,12 @@
 		color: rgba(248, 250, 252, 0.92);
 	}
 
+	@media (prefers-color-scheme: dark) {
+		.slogan__primary {
+			color: rgba(248, 250, 252, 0.92);
+		}
+	}
+
 	.slogan__secondary {
 		font-size: clamp(1.1rem, 2.2vw, 1.7rem);
 		font-weight: 400;
@@ -332,6 +324,12 @@
 
 	:global([data-theme='dark'] .slogan__secondary) {
 		color: rgba(203, 213, 245, 0.78);
+	}
+
+	@media (prefers-color-scheme: dark) {
+		.slogan__secondary {
+			color: rgba(203, 213, 245, 0.78);
+		}
 	}
 
 	.cta {
@@ -393,6 +391,14 @@
 		box-shadow: 0 32px 84px rgba(8, 11, 21, 0.88);
 	}
 
+	@media (prefers-color-scheme: dark) {
+		.video-shell {
+			background: linear-gradient(150deg, rgba(88, 28, 135, 0.5), rgba(2, 6, 23, 0.95));
+			border-color: rgba(148, 163, 184, 0.26);
+			box-shadow: 0 32px 84px rgba(8, 11, 21, 0.88);
+		}
+	}
+
 	.video-shell__halo {
 		position: absolute;
 		inset: 0;
@@ -410,6 +416,13 @@
 	:global([data-theme='dark'] .video-shell__halo) {
 		background: radial-gradient(circle at 45% 55%, rgba(129, 140, 248, 0.42), transparent 72%);
 		opacity: 0.6;
+	}
+
+	@media (prefers-color-scheme: dark) {
+		.video-shell__halo {
+			background: radial-gradient(circle at 45% 55%, rgba(129, 140, 248, 0.42), transparent 72%);
+			opacity: 0.6;
+		}
 	}
 
 	@media (min-width: 640px) {
@@ -439,6 +452,14 @@
 		background: linear-gradient(155deg, rgba(59, 130, 246, 0.18), rgba(2, 6, 23, 0.88));
 		border-color: rgba(148, 163, 184, 0.18);
 		opacity: 0.52;
+	}
+
+	@media (prefers-color-scheme: dark) {
+		.video-shell__inner {
+			background: linear-gradient(155deg, rgba(59, 130, 246, 0.18), rgba(2, 6, 23, 0.88));
+			border-color: rgba(148, 163, 184, 0.18);
+			opacity: 0.52;
+		}
 	}
 
 	.video-shell__media {
@@ -513,6 +534,14 @@
 		border-color: rgba(148, 163, 184, 0.24);
 		background: var(--sound-toggle-bg);
 		color: var(--sound-toggle-foreground);
+	}
+
+	@media (prefers-color-scheme: dark) {
+		.sound-toggle {
+			border-color: rgba(148, 163, 184, 0.24);
+			background: var(--sound-toggle-bg);
+			color: var(--sound-toggle-foreground);
+		}
 	}
 
 	.sound-toggle:hover {

--- a/web/src/routes/app/+page.svelte
+++ b/web/src/routes/app/+page.svelte
@@ -374,6 +374,7 @@
 	function applyTheme(mode: 'light' | 'dark') {
 		if (typeof document === 'undefined') return;
 		const root = document.documentElement;
+		root.dataset.theme = mode;
 		root.classList.toggle('dark', mode === 'dark');
 		root.style.colorScheme = mode;
 		if (typeof localStorage !== 'undefined') {


### PR DESCRIPTION
## Summary
- add prefers-color-scheme fallbacks so the marketing page renders without a light-to-dark flash
- sync root theme color variables with CSS media queries and update helpers to set color-scheme metadata
- ensure app theme toggles store the selected mode in data-theme for consistent overrides

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d25dfaf75c832e91ce775fe9743e19