### PR TITLE
[docs/web] document TEST_USER bypass for local auth testing

### DIFF
--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -28,6 +28,7 @@ This is a SvelteKit app, it usees latest version of Svelte and SvelteKit, docs a
 
 - Notes
   - Follow `docs/SPEC.md` for auth and validation requirements. All external inputs must be validated with `zod` and normalized before use.
+  - Local testing already sets the `TEST_USER` environment variable to a valid test account (see `docs/SPEC.md`). When this flag is present the hooks short-circuit authentication so you can browse pages such as `/code` without signing in.
 
 **Gemini**
 


### PR DESCRIPTION
## Summary
- document in web/AGENTS.md that the TEST_USER environment variable is preconfigured for local testing and bypasses auth
- note that this enables visiting protected routes such as /code without signing in

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dec4289864832ea2da25e6cf6982a3