### PR TITLE
[feat/web] refresh dp session flow

### DIFF
--- a/web/src/lib/components/quiz/index.ts
+++ b/web/src/lib/components/quiz/index.ts
@@ -2,3 +2,4 @@ export { default as QuizQuestionCard } from './quiz-question-card.svelte';
 export { default as QuizProgress } from './quiz-progress.svelte';
 export { default as QuizMultipleChoice } from './quiz-multiple-choice.svelte';
 export { default as QuizTypeAnswer } from './quiz-type-answer.svelte';
+export { default as QuizInfoCard } from './quiz-info-card.svelte';

--- a/web/src/lib/components/quiz/quiz-info-card.svelte
+++ b/web/src/lib/components/quiz/quiz-info-card.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+        import { createEventDispatcher } from 'svelte';
+        import QuizQuestionCard from './quiz-question-card.svelte';
+        import { Button } from '$lib/components/ui/button/index.js';
+        import type { QuizInfoCardQuestion } from '$lib/types/quiz';
+
+        const dispatch = createEventDispatcher<{ continue: void }>();
+
+        type Props = {
+                question: QuizInfoCardQuestion;
+                continueLabel?: string;
+        };
+
+        let { question, continueLabel = 'Continue' }: Props = $props();
+
+        function handleContinue() {
+                dispatch('continue');
+        }
+</script>
+
+<QuizQuestionCard
+        title={question.prompt}
+        eyebrow={question.eyebrow ?? null}
+        status="neutral"
+        displayFooter={false}
+>
+        <div class="space-y-4">
+                <p class="text-base leading-relaxed text-foreground/90 dark:text-foreground">
+                        {question.body}
+                </p>
+                {#if question.bullets?.length}
+                        <ul class="space-y-2 text-base leading-relaxed text-foreground/90">
+                                {#each question.bullets as bullet}
+                                        <li class="flex items-start gap-2">
+                                                <span class="mt-1 inline-flex size-2 shrink-0 rounded-full bg-primary"></span>
+                                                <span class="flex-1">{bullet}</span>
+                                        </li>
+                                {/each}
+                        </ul>
+                {/if}
+        </div>
+
+        <div class="mt-6 flex justify-end">
+                <Button size="lg" onclick={handleContinue}>{continueLabel}</Button>
+        </div>
+</QuizQuestionCard>

--- a/web/src/lib/config/code-plan.ts
+++ b/web/src/lib/config/code-plan.ts
@@ -1,0 +1,58 @@
+import type { CodeProgressStepKey } from '$lib/types/code-progress';
+
+type CodePlanStep = {
+        key: CodeProgressStepKey;
+        title: string;
+        icon: string;
+        meta: string;
+        description: string;
+        href: string;
+};
+
+export const dynamicProgrammingPlan: readonly CodePlanStep[] = [
+        {
+                key: 'warmup',
+                title: 'Warm-up quiz',
+                icon: '⚡',
+                meta: '3 Q · 4 min',
+                description: 'Shake off the rust with quick DP fundamentals.',
+                href: '/code/quiz/dp-warmup'
+        },
+        {
+                key: 'topic',
+                title: 'Topic deck',
+                icon: '📘',
+                meta: '5 cards · guided',
+                description: 'Walk through the core DP mindset with gentle check-ins.',
+                href: '/code/quiz/dp-topic'
+        },
+        {
+                key: 'problem-one',
+                title: 'Coin Change Ways',
+                icon: '🪙',
+                meta: 'DP · Easy',
+                description: 'Count ways to form an amount with unlimited coins.',
+                href: '/code/p/coin-change-ways'
+        },
+        {
+                key: 'problem-two',
+                title: 'Decode Ways',
+                icon: '🔐',
+                meta: 'DP · Easy',
+                description: 'Use a simple DP to decode strings of digits.',
+                href: '/code/p/decode-ways'
+        },
+        {
+                key: 'review',
+                title: 'Final review quiz',
+                icon: '✅',
+                meta: '3 Q · 4 min',
+                description: 'Lock in the takeaways before moving on.',
+                href: '/code/quiz/dp-review'
+        }
+] as const;
+
+export const problemStepBySlug: Partial<Record<string, CodeProgressStepKey>> = {
+        'coin-change-ways': 'problem-one',
+        'decode-ways': 'problem-two'
+};

--- a/web/src/lib/server/quiz/mock-data.ts
+++ b/web/src/lib/server/quiz/mock-data.ts
@@ -1,77 +1,191 @@
 import type { QuizDefinition } from '$lib/types/quiz';
 
-export const dynamicProgrammingQuiz: QuizDefinition = {
-	id: 'dynamic-programming-foundations',
-	title: 'Dynamic Programming Starter Quiz',
-	topic: 'Dynamic Programming',
-	estimatedMinutes: 8,
-	description:
-		'Warm up with overlapping subproblems, transitions, and naming conventions used in interview-style DP questions.',
-	questions: [
-		{
-			kind: 'multiple-choice',
-			id: 'dp-overlap-properties',
-			prompt: 'Which pair of properties must hold before dynamic programming is a good fit?',
-			hint: 'Think about repeated work and whether substructures can be combined.',
-			explanation:
-				'Dynamic programming is valuable when subproblems repeat across branches and a global solution can be composed from optimal subproblem answers.',
-			options: [
-				{ id: 'A', label: 'A', text: 'Greedy-choice property and logarithmic complexity' },
-				{ id: 'B', label: 'B', text: 'Deterministic transitions and acyclic graphs' },
-				{ id: 'C', label: 'C', text: 'Overlapping subproblems and optimal substructure' },
-				{ id: 'D', label: 'D', text: 'Divide-and-conquer decomposition and prefix sums' }
-			],
-			correctOptionId: 'C'
-		},
-		{
-			kind: 'multiple-choice',
-			id: 'dp-space-optimisation',
-			prompt: 'When converting a two-dimensional DP table to a rolling array, what requirement must hold?',
-			hint: 'Look at how state transitions read previous rows or columns.',
-			explanation:
-				'Rolling arrays only work when each state depends on a limited window of prior states, such as the previous row or column, so overwritten entries are never read again.',
-			options: [
-				{ id: 'A', label: 'A', text: 'Each cell depends only on its diagonal neighbour' },
-				{ id: 'B', label: 'B', text: 'Transitions read no more than one previous layer' },
-				{ id: 'C', label: 'C', text: 'State transitions form a tree without cycles' },
-				{ id: 'D', label: 'D', text: 'The table indices are strictly increasing in both axes' }
-			],
-			correctOptionId: 'B'
-		},
-		{
-			kind: 'multiple-choice',
-			id: 'dp-transition-order',
-			prompt: 'Tabulation requires evaluating states in which order?',
-			hint: 'Follow the dependency graph of your transitions.',
-			explanation:
-				'Tabulation fills the table iteratively so every dependency is ready before a state is computed, typically moving from base cases up to the target state.',
-			options: [
-				{ id: 'A', label: 'A', text: 'Any order, because memoization handles recursion' },
-				{ id: 'B', label: 'B', text: 'Descending order from target state to base cases' },
-				{ id: 'C', label: 'C', text: 'A topological order that respects each transition' },
-				{ id: 'D', label: 'D', text: 'Breadth-first order by Manhattan distance' }
-			],
-			correctOptionId: 'C'
-		},
-		{
-			kind: 'type-answer',
-			id: 'dp-top-down-term',
-			prompt: 'What is the top-down technique that caches recursive results to avoid repeated work?',
-			hint: 'It pairs recursion with a hash map or array to remember answers.',
-			explanation:
-				'Recursive memoization stores the outcome of subproblems so subsequent calls can return instantly instead of recomputing.',
-			answer: 'memoization',
-			acceptableAnswers: ['memoisation']
-		},
-		{
-			kind: 'type-answer',
-			id: 'dp-table-name',
-			prompt: 'In a coin change tabulation with states dp[amount], what value does dp[0] store?',
-			hint: 'How many ways exist to form zero value?',
-			explanation:
-				'Setting dp[0] = 1 encodes the base case that there is exactly one way to form zero amount: choose no coins.',
-			answer: '1',
-			acceptableAnswers: ['one']
-		}
-	]
+export const dynamicProgrammingWarmupQuiz: QuizDefinition = {
+        id: 'dp-warmup',
+        title: 'DP Warm-up Quiz',
+        topic: 'Dynamic Programming',
+        estimatedMinutes: 4,
+        description: 'Three quick questions to make sure the DP basics are fresh.',
+        progressKey: 'warmup',
+        questions: [
+                {
+                        kind: 'multiple-choice',
+                        id: 'dp-signal-fit',
+                        prompt: 'When is a DP approach usually a good fit?',
+                        hint: 'Look for repeat work and the ability to build larger answers.',
+                        explanation:
+                                'Dynamic programming shines when subproblems repeat and the final answer can be composed from optimal subproblem answers.',
+                        options: [
+                                { id: 'A', label: 'A', text: 'Whenever the input size is small' },
+                                { id: 'B', label: 'B', text: 'When greedy choice is clearly optimal' },
+                                {
+                                        id: 'C',
+                                        label: 'C',
+                                        text: 'When subproblems overlap and combine into an optimal whole'
+                                },
+                                { id: 'D', label: 'D', text: 'If the solution only needs sorting' }
+                        ],
+                        correctOptionId: 'C'
+                },
+                {
+                        kind: 'multiple-choice',
+                        id: 'dp-base-cases',
+                        prompt: 'Why do we seed base cases before filling a DP table?',
+                        hint: 'Think about the very first states we depend on.',
+                        explanation:
+                                'Base cases stop recursion or kick off tabulation so every later state has something concrete to lean on.',
+                        options: [
+                                { id: 'A', label: 'A', text: 'To avoid using recursion entirely' },
+                                { id: 'B', label: 'B', text: 'They remove the need for transitions' },
+                                {
+                                        id: 'C',
+                                        label: 'C',
+                                        text: 'They provide the first solved states required by later transitions'
+                                },
+                                { id: 'D', label: 'D', text: 'To guarantee O(1) memory' }
+                        ],
+                        correctOptionId: 'C'
+                },
+                {
+                        kind: 'type-answer',
+                        id: 'dp-memo-term',
+                        prompt: 'What do we call the top-down technique that caches answers to avoid duplicate recursion?',
+                        hint: 'It pairs recursion with a map or array.',
+                        explanation: 'Top-down DP with a cache is called memoization.',
+                        answer: 'memoization',
+                        acceptableAnswers: ['memoisation']
+                }
+        ]
+};
+
+export const dynamicProgrammingTopicDeck: QuizDefinition = {
+        id: 'dp-topic',
+        title: 'DP Topic Deck',
+        topic: 'Dynamic Programming',
+        estimatedMinutes: 6,
+        description: 'Two quick info cards followed by three gentle check-ins to cement the DP mindset.',
+        progressKey: 'topic',
+        questions: [
+                {
+                        kind: 'info-card',
+                        id: 'dp-info-states',
+                        prompt: 'Build a simple DP state',
+                        body: 'Think of DP as bookkeeping. We choose a state that captures “progress so far”—for 1D problems that is often the index or amount we have already processed. A smaller state means fewer entries to fill.',
+                        bullets: [
+                                'Pick a clear meaning for dp[i], e.g. number of ways to reach total i.',
+                                'List the smallest states that can be answered immediately (base cases).'
+                        ],
+                        actionLabel: 'Got it'
+                },
+                {
+                        kind: 'info-card',
+                        id: 'dp-info-transitions',
+                        prompt: 'Plan the transitions',
+                        body: 'Ask “How can I move from one state to the next?” For coin change, every coin lets you extend a smaller amount. For decoding, a one- or two-digit chunk extends the prefix answer.',
+                        bullets: [
+                                'Transitions only use already-computed states.',
+                                'Keep each step tiny: add a coin, read one or two characters, etc.'
+                        ],
+                        actionLabel: 'Next card'
+                },
+                {
+                        kind: 'multiple-choice',
+                        id: 'dp-state-definition',
+                        prompt: 'If dp[i] stores the number of ways to reach amount i, what should dp[0] be?',
+                        explanation: 'We set dp[0] = 1 to represent the single way to make zero (choose no coins).',
+                        options: [
+                                { id: 'A', label: 'A', text: '0, because no coins are used' },
+                                { id: 'B', label: 'B', text: '1, representing the empty combination' },
+                                { id: 'C', label: 'C', text: 'Depends on the coin set' },
+                                { id: 'D', label: 'D', text: 'The smallest coin value' }
+                        ],
+                        correctOptionId: 'B'
+                },
+                {
+                        kind: 'multiple-choice',
+                        id: 'dp-transition-choice',
+                        prompt: 'For decoding ways, which transition keeps the DP table easy?',
+                        hint: 'Focus on how many characters you consume each step.',
+                        explanation:
+                                'We extend the prefix by consuming one digit (if valid) or two digits (if they form 10–26). Each adds the count from the earlier prefix.',
+                        options: [
+                                { id: 'A', label: 'A', text: 'Jump three digits at a time' },
+                                { id: 'B', label: 'B', text: 'Only use the previous digit' },
+                                {
+                                        id: 'C',
+                                        label: 'C',
+                                        text: 'Add the counts from one-digit and two-digit extensions when valid'
+                                },
+                                { id: 'D', label: 'D', text: 'Multiply the counts together' }
+                        ],
+                        correctOptionId: 'C'
+                },
+                {
+                        kind: 'multiple-choice',
+                        id: 'dp-iteration-order',
+                        prompt: 'When tabulating a 1D DP such as coin change, which iteration order keeps dependencies ready?',
+                        explanation:
+                                'Iterating amount from 0 upwards ensures every smaller amount is already computed when we need it.',
+                        options: [
+                                { id: 'A', label: 'A', text: 'Descending from target to 0' },
+                                { id: 'B', label: 'B', text: 'Random order' },
+                                { id: 'C', label: 'C', text: 'Ascending from 0 to target' },
+                                { id: 'D', label: 'D', text: 'Only iterate the base cases' }
+                        ],
+                        correctOptionId: 'C'
+                }
+        ]
+};
+
+export const dynamicProgrammingReviewQuiz: QuizDefinition = {
+        id: 'dp-review',
+        title: 'DP Review Quiz',
+        topic: 'Dynamic Programming',
+        estimatedMinutes: 4,
+        description: 'A final, easy check to lock in what you just practiced.',
+        progressKey: 'review',
+        questions: [
+                {
+                        kind: 'multiple-choice',
+                        id: 'dp-why-tabulate',
+                        prompt: 'Why does tabulation help avoid recursion depth issues?',
+                        explanation:
+                                'Tabulation fills the table iteratively, so we never build a deep call stack and still reuse every computed state.',
+                        options: [
+                                { id: 'A', label: 'A', text: 'It uses divide and conquer instead of DP' },
+                                { id: 'B', label: 'B', text: 'We precompute answers iteratively without recursion' },
+                                { id: 'C', label: 'C', text: 'It randomly guesses answers then fixes them' },
+                                { id: 'D', label: 'D', text: 'It sorts the input to avoid recursion' }
+                        ],
+                        correctOptionId: 'B'
+                },
+                {
+                        kind: 'multiple-choice',
+                        id: 'dp-space-trick',
+                        prompt: 'When can you safely compress a 2D DP into a 1D array?',
+                        hint: 'Only when transitions rely on the previous row or column.',
+                        explanation:
+                                'If each state only depends on the immediately previous row or column, we can reuse a rolling array without losing data.',
+                        options: [
+                                { id: 'A', label: 'A', text: 'Whenever the answer fits in memory' },
+                                { id: 'B', label: 'B', text: 'Only when the table is symmetric' },
+                                {
+                                        id: 'C',
+                                        label: 'C',
+                                        text: 'When transitions read from a limited window such as the prior row'
+                                },
+                                { id: 'D', label: 'D', text: 'Never—it always changes the answer' }
+                        ],
+                        correctOptionId: 'C'
+                },
+                {
+                        kind: 'type-answer',
+                        id: 'dp-reuse-answer',
+                        prompt: 'Fill in the blank: Dynamic programming trades ______ for time.',
+                        hint: 'We store answers so we do not recompute them.',
+                        explanation: 'Dynamic programming spends extra memory to avoid recomputation.',
+                        answer: 'memory',
+                        acceptableAnswers: ['space']
+                }
+        ]
 };

--- a/web/src/lib/stores/codeProgress.ts
+++ b/web/src/lib/stores/codeProgress.ts
@@ -1,0 +1,78 @@
+import { writable } from 'svelte/store';
+import type { CodeProgressState, CodeProgressStepKey } from '$lib/types/code-progress';
+
+const STORAGE_KEY = 'spark-code-progress';
+
+const defaultState: CodeProgressState = {
+        warmup: false,
+        topic: false,
+        'problem-one': false,
+        'problem-two': false,
+        review: false
+};
+
+function loadFromStorage(): CodeProgressState {
+        if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') {
+                return { ...defaultState };
+        }
+
+        try {
+                const raw = window.localStorage.getItem(STORAGE_KEY);
+                if (!raw) {
+                        return { ...defaultState };
+                }
+                const parsed = JSON.parse(raw) as Partial<CodeProgressState>;
+                return { ...defaultState, ...parsed };
+        } catch (error) {
+                console.error('Failed to read code progress from storage', error);
+                return { ...defaultState };
+        }
+}
+
+function persist(state: CodeProgressState) {
+        if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') {
+                return;
+        }
+        try {
+                        window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+        } catch (error) {
+                console.error('Failed to persist code progress', error);
+        }
+}
+
+const { subscribe, set, update } = writable<CodeProgressState>(loadFromStorage());
+
+function sync() {
+        set(loadFromStorage());
+}
+
+function markComplete(step: CodeProgressStepKey) {
+        update((state) => {
+                if (state[step]) {
+                        return state;
+                }
+                const next = { ...state, [step]: true } as CodeProgressState;
+                persist(next);
+                return next;
+        });
+}
+
+function reset() {
+        persist(defaultState);
+        set({ ...defaultState });
+}
+
+function getSnapshot(): CodeProgressState {
+        return loadFromStorage();
+}
+
+export const codeProgress = {
+        subscribe,
+        sync,
+        markComplete,
+        reset,
+        getSnapshot,
+        defaultState: { ...defaultState }
+};
+
+export type { CodeProgressState, CodeProgressStepKey };

--- a/web/src/lib/types/code-progress.ts
+++ b/web/src/lib/types/code-progress.ts
@@ -1,0 +1,8 @@
+export type CodeProgressStepKey =
+        | 'warmup'
+        | 'topic'
+        | 'problem-one'
+        | 'problem-two'
+        | 'review';
+
+export type CodeProgressState = Record<CodeProgressStepKey, boolean>;

--- a/web/src/lib/types/quiz.ts
+++ b/web/src/lib/types/quiz.ts
@@ -1,9 +1,11 @@
+import type { CodeProgressStepKey } from '$lib/types/code-progress';
+
 export type QuizQuestionBase = {
-	id: string;
-	prompt: string;
-	hint?: string;
-	explanation?: string;
-	audioLabel?: string;
+        id: string;
+        prompt: string;
+        hint?: string;
+        explanation?: string;
+        audioLabel?: string;
 };
 
 export type QuizChoiceOption = {
@@ -25,7 +27,20 @@ export type QuizTypeAnswerQuestion = QuizQuestionBase & {
 	placeholder?: string;
 };
 
-export type QuizQuestion = QuizMultipleChoiceQuestion | QuizTypeAnswerQuestion;
+export type QuizInfoCardQuestion = {
+        kind: 'info-card';
+        id: string;
+        prompt: string;
+        body: string;
+        eyebrow?: string | null;
+        bullets?: readonly string[];
+        actionLabel?: string;
+};
+
+export type QuizQuestion =
+        | QuizMultipleChoiceQuestion
+        | QuizTypeAnswerQuestion
+        | QuizInfoCardQuestion;
 
 export type QuizFeedbackTone = 'info' | 'success' | 'warning';
 
@@ -44,10 +59,11 @@ export type QuizProgressStep = {
 };
 
 export type QuizDefinition = {
-	id: string;
-	title: string;
-	description?: string;
-	topic?: string;
-	estimatedMinutes?: number;
-	questions: readonly QuizQuestion[];
+        id: string;
+        title: string;
+        description?: string;
+        topic?: string;
+        estimatedMinutes?: number;
+        questions: readonly QuizQuestion[];
+        progressKey?: CodeProgressStepKey;
 };

--- a/web/src/routes/(app)/code/p/[id]/+page.svelte
+++ b/web/src/routes/(app)/code/p/[id]/+page.svelte
@@ -1,13 +1,15 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
-	import * as Resizable from '$lib/components/ui/resizable/index.js';
-	import { buttonVariants } from '$lib/components/ui/button/index.js';
-	import { cn } from '$lib/utils.js';
-	import { loadMonaco } from '$lib/monaco/index.js';
-	import type { editor as MonacoEditorNS, IDisposable } from 'monaco-editor';
-	import Maximize2 from '@lucide/svelte/icons/maximize-2';
-	import Minimize2 from '@lucide/svelte/icons/minimize-2';
-	import type { PageData } from './$types';
+        import { onMount } from 'svelte';
+        import * as Resizable from '$lib/components/ui/resizable/index.js';
+        import { buttonVariants } from '$lib/components/ui/button/index.js';
+        import { cn } from '$lib/utils.js';
+        import { loadMonaco } from '$lib/monaco/index.js';
+        import type { editor as MonacoEditorNS, IDisposable } from 'monaco-editor';
+        import Maximize2 from '@lucide/svelte/icons/maximize-2';
+        import Minimize2 from '@lucide/svelte/icons/minimize-2';
+        import type { PageData } from './$types';
+        import { problemStepBySlug } from '$lib/config/code-plan';
+        import { codeProgress } from '$lib/stores/codeProgress';
 
 	type PaneSide = 'left' | 'right';
 
@@ -61,11 +63,11 @@
 		}
 	}
 
-	onMount(() => {
-		let subscription: IDisposable | null = null;
-		let themeObserver: MutationObserver | null = null;
-		let mediaQuery: MediaQueryList | null = null;
-		let applyTheme: (() => void) | null = null;
+        onMount(() => {
+                let subscription: IDisposable | null = null;
+                let themeObserver: MutationObserver | null = null;
+                let mediaQuery: MediaQueryList | null = null;
+                let applyTheme: (() => void) | null = null;
 
 		void (async () => {
 			const monaco = await loadMonaco();
@@ -125,11 +127,18 @@
 			applyTheme = null;
 		};
 
-		return () => {
-			disposeEditor?.();
-			disposeEditor = null;
-		};
-	});
+                return () => {
+                        disposeEditor?.();
+                        disposeEditor = null;
+                };
+        });
+
+        onMount(() => {
+                const step = problemStepBySlug[problem.id];
+                if (step) {
+                        codeProgress.markComplete(step);
+                }
+        });
 
 	function applyLayout(layout: readonly number[]) {
 		paneGroup?.setLayout([...layout]);

--- a/web/src/routes/(app)/code/quiz/[id]/+page.server.ts
+++ b/web/src/routes/(app)/code/quiz/[id]/+page.server.ts
@@ -1,16 +1,22 @@
 import type { PageServerLoad } from './$types';
-import { dynamicProgrammingQuiz } from '$lib/server/quiz/mock-data';
+import {
+        dynamicProgrammingReviewQuiz,
+        dynamicProgrammingTopicDeck,
+        dynamicProgrammingWarmupQuiz
+} from '$lib/server/quiz/mock-data';
 import type { QuizDefinition } from '$lib/types/quiz';
 
 const registry = new Map<string, QuizDefinition>([
-	[dynamicProgrammingQuiz.id, dynamicProgrammingQuiz]
+        [dynamicProgrammingWarmupQuiz.id, dynamicProgrammingWarmupQuiz],
+        [dynamicProgrammingTopicDeck.id, dynamicProgrammingTopicDeck],
+        [dynamicProgrammingReviewQuiz.id, dynamicProgrammingReviewQuiz]
 ]);
 
 export const load: PageServerLoad = async ({ params }) => {
-	const { id } = params;
-	const quiz = registry.get(id) ?? dynamicProgrammingQuiz;
+        const { id } = params;
+        const quiz = registry.get(id) ?? dynamicProgrammingWarmupQuiz;
 
-	return {
-		quiz
+        return {
+                quiz
 	};
 };


### PR DESCRIPTION
## Summary
- rework the /code session timeline around a five-step dynamic programming plan with persistent local progress
- add lightweight DP warm-up, topic deck, and review quizzes including support for info-card slides and completion modal
- surface existing DP problems in the plan and auto-mark steps complete when users open problems or finish quizzes

## Testing
- `npm --prefix spark/web run lint` *(fails: missing svelte-kit binary in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df72077654832e8c381e0ecd124dff