### PR TITLE
feat: focus coding plan on dp easy sprint

### DIFF
--- a/web/src/lib/components/quiz/index.ts
+++ b/web/src/lib/components/quiz/index.ts
@@ -2,3 +2,4 @@ export { default as QuizQuestionCard } from './quiz-question-card.svelte';
 export { default as QuizProgress } from './quiz-progress.svelte';
 export { default as QuizMultipleChoice } from './quiz-multiple-choice.svelte';
 export { default as QuizTypeAnswer } from './quiz-type-answer.svelte';
+export { default as QuizInfoCard } from './quiz-info-card.svelte';

--- a/web/src/lib/components/quiz/quiz-info-card.svelte
+++ b/web/src/lib/components/quiz/quiz-info-card.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+        import { createEventDispatcher } from 'svelte';
+        import QuizQuestionCard from './quiz-question-card.svelte';
+        import { Button } from '$lib/components/ui/button/index.js';
+        import type { QuizInfoCardQuestion } from '$lib/types/quiz';
+
+        type Status = 'neutral' | 'correct' | 'incorrect';
+
+        const dispatch = createEventDispatcher<{ continue: void }>();
+
+        type Props = {
+                question: QuizInfoCardQuestion;
+                continueLabel?: string;
+                status?: Status;
+        };
+
+        let {
+                question,
+                continueLabel = question.continueLabel ?? 'Next',
+                status: statusProp = 'neutral' as Status
+        }: Props = $props();
+
+        const eyebrow = $derived(question.eyebrow ?? 'Concept spotlight');
+
+        function handleContinue() {
+                dispatch('continue');
+        }
+</script>
+
+<QuizQuestionCard
+        title={question.prompt}
+        status={statusProp}
+        eyebrow={eyebrow}
+        displayFooter={true}
+>
+        <div class="space-y-4">
+                <p class="text-base leading-relaxed text-foreground/90">
+                        {question.body}
+                </p>
+        </div>
+
+        <div slot="footer" class="ml-auto flex items-center gap-2">
+                <Button size="lg" onclick={handleContinue}>{continueLabel}</Button>
+        </div>
+</QuizQuestionCard>

--- a/web/src/lib/server/quiz/mock-data.ts
+++ b/web/src/lib/server/quiz/mock-data.ts
@@ -1,77 +1,191 @@
 import type { QuizDefinition } from '$lib/types/quiz';
 
-export const dynamicProgrammingQuiz: QuizDefinition = {
-	id: 'dynamic-programming-foundations',
-	title: 'Dynamic Programming Starter Quiz',
-	topic: 'Dynamic Programming',
-	estimatedMinutes: 8,
-	description:
-		'Warm up with overlapping subproblems, transitions, and naming conventions used in interview-style DP questions.',
-	questions: [
-		{
-			kind: 'multiple-choice',
-			id: 'dp-overlap-properties',
-			prompt: 'Which pair of properties must hold before dynamic programming is a good fit?',
-			hint: 'Think about repeated work and whether substructures can be combined.',
-			explanation:
-				'Dynamic programming is valuable when subproblems repeat across branches and a global solution can be composed from optimal subproblem answers.',
-			options: [
-				{ id: 'A', label: 'A', text: 'Greedy-choice property and logarithmic complexity' },
-				{ id: 'B', label: 'B', text: 'Deterministic transitions and acyclic graphs' },
-				{ id: 'C', label: 'C', text: 'Overlapping subproblems and optimal substructure' },
-				{ id: 'D', label: 'D', text: 'Divide-and-conquer decomposition and prefix sums' }
-			],
-			correctOptionId: 'C'
-		},
-		{
-			kind: 'multiple-choice',
-			id: 'dp-space-optimisation',
-			prompt: 'When converting a two-dimensional DP table to a rolling array, what requirement must hold?',
-			hint: 'Look at how state transitions read previous rows or columns.',
-			explanation:
-				'Rolling arrays only work when each state depends on a limited window of prior states, such as the previous row or column, so overwritten entries are never read again.',
-			options: [
-				{ id: 'A', label: 'A', text: 'Each cell depends only on its diagonal neighbour' },
-				{ id: 'B', label: 'B', text: 'Transitions read no more than one previous layer' },
-				{ id: 'C', label: 'C', text: 'State transitions form a tree without cycles' },
-				{ id: 'D', label: 'D', text: 'The table indices are strictly increasing in both axes' }
-			],
-			correctOptionId: 'B'
-		},
-		{
-			kind: 'multiple-choice',
-			id: 'dp-transition-order',
-			prompt: 'Tabulation requires evaluating states in which order?',
-			hint: 'Follow the dependency graph of your transitions.',
-			explanation:
-				'Tabulation fills the table iteratively so every dependency is ready before a state is computed, typically moving from base cases up to the target state.',
-			options: [
-				{ id: 'A', label: 'A', text: 'Any order, because memoization handles recursion' },
-				{ id: 'B', label: 'B', text: 'Descending order from target state to base cases' },
-				{ id: 'C', label: 'C', text: 'A topological order that respects each transition' },
-				{ id: 'D', label: 'D', text: 'Breadth-first order by Manhattan distance' }
-			],
-			correctOptionId: 'C'
-		},
-		{
-			kind: 'type-answer',
-			id: 'dp-top-down-term',
-			prompt: 'What is the top-down technique that caches recursive results to avoid repeated work?',
-			hint: 'It pairs recursion with a hash map or array to remember answers.',
-			explanation:
-				'Recursive memoization stores the outcome of subproblems so subsequent calls can return instantly instead of recomputing.',
-			answer: 'memoization',
-			acceptableAnswers: ['memoisation']
-		},
-		{
-			kind: 'type-answer',
-			id: 'dp-table-name',
-			prompt: 'In a coin change tabulation with states dp[amount], what value does dp[0] store?',
-			hint: 'How many ways exist to form zero value?',
-			explanation:
-				'Setting dp[0] = 1 encodes the base case that there is exactly one way to form zero amount: choose no coins.',
-			answer: '1',
-			acceptableAnswers: ['one']
-		}
-	]
+export const dynamicProgrammingWarmupQuiz: QuizDefinition = {
+        id: 'dp-warmup-quiz',
+        title: 'DP Warm-up: Core Ideas',
+        topic: 'Dynamic Programming',
+        estimatedMinutes: 4,
+        progressKey: 'warmup',
+        description: 'Three quick checks on overlapping subproblems, base cases, and tabulation flow.',
+        questions: [
+                {
+                        kind: 'multiple-choice',
+                        id: 'dp-warmup-overlap',
+                        prompt: 'When do overlapping subproblems appear?',
+                        hint: 'Look for recursion that revisits the same state.',
+                        explanation:
+                                'Overlapping subproblems happen when different recursion branches compute the same state, such as dp(amount) for the same amount in coin change.',
+                        options: [
+                                { id: 'A', label: 'A', text: 'When each recursive call produces a unique state' },
+                                { id: 'B', label: 'B', text: 'When the same subproblem is needed in multiple branches' },
+                                { id: 'C', label: 'C', text: 'Only when a problem uses graphs' },
+                                { id: 'D', label: 'D', text: 'Whenever a greedy choice is possible' }
+                        ],
+                        correctOptionId: 'B'
+                },
+                {
+                        kind: 'multiple-choice',
+                        id: 'dp-warmup-base-case',
+                        prompt: 'In a counting DP (ways to form a sum), what does the base case dp[0] usually equal?',
+                        hint: 'Consider how many ways exist to pick nothing.',
+                        explanation:
+                                'Setting dp[0] = 1 encodes the single way to make zero — pick no elements. It seeds the recurrence for positive amounts.',
+                        options: [
+                                { id: 'A', label: 'A', text: '0, because no work is needed' },
+                                { id: 'B', label: 'B', text: '1, representing the empty choice' },
+                                { id: 'C', label: 'C', text: 'The smallest coin value' },
+                                { id: 'D', label: 'D', text: 'Undefined until we process input' }
+                        ],
+                        correctOptionId: 'B'
+                },
+                {
+                        kind: 'multiple-choice',
+                        id: 'dp-warmup-order',
+                        prompt: 'Why do tabulation solutions fill states in a specific order?',
+                        hint: 'Think about dependencies between states.',
+                        explanation:
+                                'Tabulation evaluates states so that every dependency is ready. The order respects the recurrence graph, similar to a topological order.',
+                        options: [
+                                { id: 'A', label: 'A', text: 'To match the call stack order of recursion exactly' },
+                                { id: 'B', label: 'B', text: 'So each state reads values that were already computed' },
+                                { id: 'C', label: 'C', text: 'Because arrays must be filled from left to right' },
+                                { id: 'D', label: 'D', text: 'To minimise memory usage with memoization' }
+                        ],
+                        correctOptionId: 'B'
+                }
+        ]
 };
+
+export const dynamicProgrammingTopicDeck: QuizDefinition = {
+        id: 'dp-topic-deck',
+        title: 'Topic Deep Dive: Coin Change Transitions',
+        topic: 'Dynamic Programming',
+        estimatedMinutes: 6,
+        progressKey: 'topic',
+        description: 'Two quick concept cards and three guided questions to lock in bottom-up coin change intuition.',
+        questions: [
+                {
+                        kind: 'info-card',
+                        id: 'dp-topic-card-1',
+                        prompt: 'Snapshot the state',
+                        eyebrow: 'Concept spotlight',
+                        body: 'For coin change we define dp[amount] as the number of ways to reach “amount”. The base case dp[0] = 1 means the empty selection is valid. Every other state will build on this anchor.',
+                        continueLabel: 'Next concept'
+                },
+                {
+                        kind: 'info-card',
+                        id: 'dp-topic-card-2',
+                        prompt: 'Build transitions carefully',
+                        eyebrow: 'Concept spotlight',
+                        body: 'When iterating coins outside the amount loop, each coin contributes combinations without caring about order. The recurrence becomes dp[amount] += dp[amount - coin] whenever amount ≥ coin.',
+                        continueLabel: "Let's quiz it"
+                },
+                {
+                        kind: 'multiple-choice',
+                        id: 'dp-topic-question-1',
+                        prompt: 'Why does iterating coins outermost avoid double counting order?',
+                        hint: 'Consider how often each coin is revisited for a given amount.',
+                        explanation:
+                                'Processing coins in the outer loop ensures each combination of coins is built once. Amounts only expand forward using the coins we have already considered.',
+                        options: [
+                                { id: 'A', label: 'A', text: 'It forces the algorithm to use each coin at most once.' },
+                                { id: 'B', label: 'B', text: 'Amounts never see a coin that has not been fully processed before.' },
+                                { id: 'C', label: 'C', text: 'It sorts the coins so permutations collapse naturally.' },
+                                { id: 'D', label: 'D', text: 'It lets us skip the base case entirely.' }
+                        ],
+                        correctOptionId: 'B'
+                },
+                {
+                        kind: 'multiple-choice',
+                        id: 'dp-topic-question-2',
+                        prompt: 'If dp[amount] counts combinations, what does dp[amount - coin] contribute in the recurrence?',
+                        hint: 'Relate the subproblem to a smaller target.',
+                        explanation:
+                                'dp[amount - coin] counts all combinations that form the smaller amount; adding the current coin extends each of those to reach the larger amount.',
+                        options: [
+                                { id: 'A', label: 'A', text: 'Only the combination that uses the largest coin.' },
+                                { id: 'B', label: 'B', text: 'All ways to form the reduced amount so we can append the current coin.' },
+                                { id: 'C', label: 'C', text: 'A placeholder zero until the outer loop ends.' },
+                                { id: 'D', label: 'D', text: 'The minimum number of coins required.' }
+                        ],
+                        correctOptionId: 'B'
+                },
+                {
+                        kind: 'multiple-choice',
+                        id: 'dp-topic-question-3',
+                        prompt: 'What happens if we flip the loops and iterate amounts outside coins?',
+                        hint: 'Watch what happens to ordering.',
+                        explanation:
+                                'Iterating amounts first counts permutations because each amount can revisit every coin in every order, inflating the total compared with combinations.',
+                        options: [
+                                { id: 'A', label: 'A', text: 'We still count combinations because subtraction is commutative.' },
+                                { id: 'B', label: 'B', text: 'We start counting ordered permutations of coins instead of combinations.' },
+                                { id: 'C', label: 'C', text: 'The algorithm fails for larger coin values.' },
+                                { id: 'D', label: 'D', text: 'dp[0] must be set to 0 to stay correct.' }
+                        ],
+                        correctOptionId: 'B'
+                }
+        ]
+};
+
+export const dynamicProgrammingReviewQuiz: QuizDefinition = {
+        id: 'dp-review-quiz',
+        title: 'DP Review: Ready for Easy Interviews',
+        topic: 'Dynamic Programming',
+        estimatedMinutes: 5,
+        progressKey: 'review',
+        description: 'Wrap up with scenario-based questions that mirror easy LeetCode DP prompts.',
+        questions: [
+                {
+                        kind: 'multiple-choice',
+                        id: 'dp-review-stairs',
+                        prompt: 'You are counting ways to climb n stairs taking 1 or 2 steps. Which recurrence fits?',
+                        hint: 'Each state depends on the previous two.',
+                        explanation:
+                                'dp[i] = dp[i - 1] + dp[i - 2] adds the paths that end with a 1-step and a 2-step, mirroring the Fibonacci pattern.',
+                        options: [
+                                { id: 'A', label: 'A', text: 'dp[i] = dp[i - 1] + 1' },
+                                { id: 'B', label: 'B', text: 'dp[i] = dp[i - 1] + dp[i - 2]' },
+                                { id: 'C', label: 'C', text: 'dp[i] = 2 * dp[i - 1]' },
+                                { id: 'D', label: 'D', text: 'dp[i] = dp[i - 1] - dp[i - 2]' }
+                        ],
+                        correctOptionId: 'B'
+                },
+                {
+                        kind: 'multiple-choice',
+                        id: 'dp-review-grid',
+                        prompt: 'For unique paths in an m×n grid moving only right or down, which base cases initialise the DP table?',
+                        hint: 'Think about the top row and left column.',
+                        explanation:
+                                'Cells in the top row and left column each have exactly one path leading to them, so setting them to 1 lets the rest of the table build off their values.',
+                        options: [
+                                { id: 'A', label: 'A', text: 'Set the diagonal to 1 and everything else to 0.' },
+                                { id: 'B', label: 'B', text: 'Set the top row and left column to 1.' },
+                                { id: 'C', label: 'C', text: 'Set only dp[0][0] = 1 and leave the rest empty.' },
+                                { id: 'D', label: 'D', text: 'Set every cell to 0 to start.' }
+                        ],
+                        correctOptionId: 'B'
+                },
+                {
+                        kind: 'multiple-choice',
+                        id: 'dp-review-memo',
+                        prompt: 'In a memoized recursion for house robber, when do we store results in the cache?',
+                        hint: 'We avoid recomputing overlapping states.',
+                        explanation:
+                                'After computing the best loot from a given index, we store it before returning so future calls reuse the cached result.',
+                        options: [
+                                { id: 'A', label: 'A', text: 'Before recursing so we can skip work entirely.' },
+                                { id: 'B', label: 'B', text: 'Right after solving a subproblem so repeated calls can reuse it.' },
+                                { id: 'C', label: 'C', text: 'Only when the answer is zero.' },
+                                { id: 'D', label: 'D', text: 'Never—we recompute each branch for clarity.' }
+                        ],
+                        correctOptionId: 'B'
+                }
+        ]
+};
+
+export const dynamicProgrammingQuizzes = [
+        dynamicProgrammingWarmupQuiz,
+        dynamicProgrammingTopicDeck,
+        dynamicProgrammingReviewQuiz
+] satisfies readonly QuizDefinition[];

--- a/web/src/lib/types/quiz.ts
+++ b/web/src/lib/types/quiz.ts
@@ -25,7 +25,17 @@ export type QuizTypeAnswerQuestion = QuizQuestionBase & {
 	placeholder?: string;
 };
 
-export type QuizQuestion = QuizMultipleChoiceQuestion | QuizTypeAnswerQuestion;
+export type QuizInfoCardQuestion = QuizQuestionBase & {
+        kind: 'info-card';
+        body: string;
+        continueLabel?: string;
+        eyebrow?: string | null;
+};
+
+export type QuizQuestion =
+        | QuizMultipleChoiceQuestion
+        | QuizTypeAnswerQuestion
+        | QuizInfoCardQuestion;
 
 export type QuizFeedbackTone = 'info' | 'success' | 'warning';
 
@@ -44,10 +54,11 @@ export type QuizProgressStep = {
 };
 
 export type QuizDefinition = {
-	id: string;
-	title: string;
-	description?: string;
-	topic?: string;
-	estimatedMinutes?: number;
-	questions: readonly QuizQuestion[];
+        id: string;
+        title: string;
+        description?: string;
+        topic?: string;
+        estimatedMinutes?: number;
+        progressKey?: string;
+        questions: readonly QuizQuestion[];
 };

--- a/web/src/routes/(app)/code/p/[id]/+page.server.ts
+++ b/web/src/routes/(app)/code/p/[id]/+page.server.ts
@@ -61,8 +61,7 @@ const firestoreProblemSchema = z
 		}),
 		metadataVersion: z.number().int().nonnegative(),
 		starterCode: z.string().optional().nullable()
-	})
-	.passthrough();
+        }).loose();
 
 type FirestoreProblem = z.infer<typeof firestoreProblemSchema>;
 

--- a/web/src/routes/(app)/code/quiz/[id]/+page.server.ts
+++ b/web/src/routes/(app)/code/quiz/[id]/+page.server.ts
@@ -1,14 +1,17 @@
 import type { PageServerLoad } from './$types';
-import { dynamicProgrammingQuiz } from '$lib/server/quiz/mock-data';
+import {
+        dynamicProgrammingQuizzes,
+        dynamicProgrammingWarmupQuiz
+} from '$lib/server/quiz/mock-data';
 import type { QuizDefinition } from '$lib/types/quiz';
 
-const registry = new Map<string, QuizDefinition>([
-	[dynamicProgrammingQuiz.id, dynamicProgrammingQuiz]
-]);
+const registry = new Map<string, QuizDefinition>(
+        dynamicProgrammingQuizzes.map((entry) => [entry.id, entry] as const)
+);
 
 export const load: PageServerLoad = async ({ params }) => {
-	const { id } = params;
-	const quiz = registry.get(id) ?? dynamicProgrammingQuiz;
+        const { id } = params;
+        const quiz = registry.get(id) ?? dynamicProgrammingWarmupQuiz;
 
 	return {
 		quiz

--- a/web/src/routes/(app)/code/quiz/[id]/+page.svelte
+++ b/web/src/routes/(app)/code/quiz/[id]/+page.svelte
@@ -1,9 +1,15 @@
 <script lang="ts">
-	import { QuizProgress, QuizMultipleChoice, QuizTypeAnswer } from '$lib/components/quiz/index.js';
-	import { Button } from '$lib/components/ui/button/index.js';
-	import * as Dialog from '$lib/components/ui/dialog/index.js';
-	import type { QuizFeedback, QuizProgressStep, QuizQuestion } from '$lib/types/quiz';
-	import type { PageData } from './$types';
+        import {
+                QuizProgress,
+                QuizMultipleChoice,
+                QuizTypeAnswer,
+                QuizInfoCard
+        } from '$lib/components/quiz/index.js';
+        import { Button } from '$lib/components/ui/button/index.js';
+        import * as Dialog from '$lib/components/ui/dialog/index.js';
+        import type { QuizFeedback, QuizProgressStep, QuizQuestion } from '$lib/types/quiz';
+        import type { PageData } from './$types';
+        import { goto } from '$app/navigation';
 
 	type AttemptStatus = 'pending' | 'correct' | 'incorrect' | 'skipped';
 
@@ -44,49 +50,81 @@
 		return 'neutral';
 	}
 
-	let attempts = $state(quiz.questions.map((_, idx) => createInitialAttempt(idx === 0)));
-	let currentIndex = $state(0);
-	let finishDialogOpen = $state(false);
+        const STORAGE_KEY = 'spark-code-progress';
+        let attempts = $state(quiz.questions.map((_, idx) => createInitialAttempt(idx === 0)));
+        let currentIndex = $state(0);
+        let finishDialogOpen = $state(false);
+        let resultDialogOpen = $state(false);
+        let progressPersisted = false;
 
-	function handleFinishDialogChange(open: boolean) {
-		finishDialogOpen = open;
-	}
+        function handleFinishDialogChange(open: boolean) {
+                finishDialogOpen = open;
+        }
+
+        function handleResultDialogChange(open: boolean) {
+                resultDialogOpen = open;
+                if (!open && isQuizComplete) {
+                        goto('/code');
+                }
+        }
 
 	function updateAttempt(index: number, updater: (value: AttemptState) => AttemptState) {
 		attempts = attempts.map((attempt, idx) => (idx === index ? updater(attempt) : attempt));
 	}
 
-	const activeQuestion = $derived(quiz.questions[currentIndex] as QuizQuestion);
-	const activeAttempt = $derived(attempts[currentIndex] ?? createInitialAttempt());
-	const progressSteps = $derived(
-		quiz.questions.map<QuizProgressStep>((_, index) => {
-			const attempt = attempts[index];
-			const label = `Question ${index + 1}`;
-			if (!attempt || attempt.status === 'pending') {
-				return {
-					status: index === currentIndex ? 'active' : attempt?.seen ? 'seen' : 'pending',
-					label
-				};
-			}
-			if (attempt.status === 'skipped') {
-				return { status: 'skipped', label };
-			}
-			return {
-				status: attempt.status === 'correct' ? 'correct' : 'incorrect',
-				label
-			};
-		})
-	);
+        const activeQuestion = $derived(quiz.questions[currentIndex] as QuizQuestion);
+        const activeAttempt = $derived(attempts[currentIndex] ?? createInitialAttempt());
+        const isLastQuestion = $derived(currentIndex === quiz.questions.length - 1);
+        const continueLabel = $derived(isLastQuestion ? 'Done' : 'Continue');
+        const progressSteps = $derived(
+                quiz.questions.map<QuizProgressStep>((question, index) => {
+                        const attempt = attempts[index];
+                        const label =
+                                question.kind === 'info-card'
+                                        ? `Step ${index + 1}`
+                                        : `Question ${index + 1}`;
+                        if (!attempt || attempt.status === 'pending') {
+                                return {
+                                        status: index === currentIndex ? 'active' : attempt?.seen ? 'seen' : 'pending',
+                                        label
+                                };
+                        }
+                        if (attempt.status === 'skipped') {
+                                return { status: 'skipped', label };
+                        }
+                        return {
+                                status: attempt.status === 'correct' ? 'correct' : 'incorrect',
+                                label
+                        };
+                })
+        );
 
-	const isQuizComplete = $derived(attempts.every((attempt) => attempt.status !== 'pending'));
-	const correctCount = $derived(attempts.filter((attempt) => attempt.status === 'correct').length);
-	const incorrectCount = $derived(
-		attempts.filter((attempt) => attempt.status === 'incorrect').length
-	);
-	const skippedCount = $derived(attempts.filter((attempt) => attempt.status === 'skipped').length);
-	const remainingCount = $derived(
-		quiz.questions.length - correctCount - incorrectCount - skippedCount
-	);
+        const scoredAttempts = $derived(
+                quiz.questions
+                        .map((question, index) => ({ question, attempt: attempts[index] }))
+                        .filter(
+                                (
+                                        entry
+                                ): entry is {
+                                        question: QuizQuestion;
+                                        attempt: AttemptState;
+                                } => entry.question.kind !== 'info-card'
+                        )
+        );
+
+        const isQuizComplete = $derived(attempts.every((attempt) => attempt.status !== 'pending'));
+        const correctCount = $derived(
+                scoredAttempts.filter((entry) => entry.attempt.status === 'correct').length
+        );
+        const incorrectCount = $derived(
+                scoredAttempts.filter((entry) => entry.attempt.status === 'incorrect').length
+        );
+        const skippedCount = $derived(
+                scoredAttempts.filter((entry) => entry.attempt.status === 'skipped').length
+        );
+        const remainingCount = $derived(
+                scoredAttempts.length - correctCount - incorrectCount - skippedCount
+        );
 
 	function goToQuestion(index: number) {
 		if (index < 0 || index >= quiz.questions.length || index === currentIndex) {
@@ -177,11 +215,11 @@
 		updateAttempt(currentIndex, (prev) => ({ ...prev, value }));
 	}
 
-	function handleTypeSubmit(value: string) {
-		const trimmed = value.trim();
-		if (!trimmed) {
-			return;
-		}
+        function handleTypeSubmit(value: string) {
+                const trimmed = value.trim();
+                if (!trimmed) {
+                        return;
+                }
 		const question = quiz.questions[currentIndex];
 		if (question.kind !== 'type-answer') {
 			return;
@@ -192,29 +230,54 @@
 		);
 		const isCorrect = accepted.includes(trimmed.toLowerCase());
 
-		updateAttempt(currentIndex, (prev) => ({
-			...prev,
-			value: trimmed,
-			status: isCorrect ? 'correct' : 'incorrect',
-			locked: true,
-			showContinue: true,
-			feedback: isCorrect
-				? {
-						heading: 'Great answer',
-						message: 'Your reasoning lines up with the model solution.'
-					}
-				: {
-						heading: "Here's the catch",
-						message: `The answer we needed appears below—study it and move forward.`
-					}
-		}));
-	}
+                updateAttempt(currentIndex, (prev) => ({
+                        ...prev,
+                        value: trimmed,
+                        status: isCorrect ? 'correct' : 'incorrect',
+                        locked: true,
+                        showContinue: true,
+                        feedback: isCorrect
+                                ? {
+                                                heading: 'Great answer',
+                                                message: 'Your reasoning lines up with the model solution.'
+                                        }
+                                : {
+                                                heading: "Here's the catch",
+                                                message: `The answer we needed appears below—study it and move forward.`
+                                        }
+                }));
+        }
 
-	function goToNextQuestion() {
-		if (currentIndex < quiz.questions.length - 1) {
-			currentIndex += 1;
-		}
-	}
+        function handleInfoContinue() {
+                const question = quiz.questions[currentIndex];
+                if (question.kind !== 'info-card') {
+                        return;
+                }
+
+                updateAttempt(currentIndex, (prev) => ({
+                        ...prev,
+                        status: 'correct',
+                        locked: true,
+                        showContinue: false,
+                        feedback: null
+                }));
+
+                advanceFlow();
+        }
+
+        function advanceFlow() {
+                if (currentIndex < quiz.questions.length - 1) {
+                        currentIndex += 1;
+                        return;
+                }
+
+                resultDialogOpen = true;
+        }
+
+        function handleAdvanceFromAttempt() {
+                updateAttempt(currentIndex, (prev) => ({ ...prev, showContinue: false }));
+                advanceFlow();
+        }
 
 	function handleFinishEarly() {
 		attempts = attempts.map((attempt) =>
@@ -231,19 +294,45 @@
 		currentIndex = Math.min(currentIndex, quiz.questions.length - 1);
 	}
 
-	function resetQuiz() {
-		attempts = quiz.questions.map((_, idx) => createInitialAttempt(idx === 0));
-		currentIndex = 0;
-		finishDialogOpen = false;
-	}
+        function resetQuiz() {
+                attempts = quiz.questions.map((_, idx) => createInitialAttempt(idx === 0));
+                currentIndex = 0;
+                finishDialogOpen = false;
+                resultDialogOpen = false;
+                progressPersisted = false;
+        }
 
 	// Mark the current question as seen whenever it becomes active
-	$effect(() => {
-		const attempt = attempts[currentIndex];
-		if (attempt && !attempt.seen) {
-			updateAttempt(currentIndex, (prev) => ({ ...prev, seen: true }));
-		}
-	});
+        $effect(() => {
+                const attempt = attempts[currentIndex];
+                if (attempt && !attempt.seen) {
+                        updateAttempt(currentIndex, (prev) => ({ ...prev, seen: true }));
+                }
+        });
+
+        $effect(() => {
+                if (!isQuizComplete) {
+                        return;
+                }
+
+                if (quiz.progressKey && !progressPersisted && typeof window !== 'undefined') {
+                        try {
+                                const raw = window.sessionStorage.getItem(STORAGE_KEY);
+                                const parsed: unknown = raw ? JSON.parse(raw) : [];
+                                const existing = Array.isArray(parsed) ? parsed : [];
+                                const next = new Set<string>(existing);
+                                next.add(quiz.progressKey);
+                                window.sessionStorage.setItem(STORAGE_KEY, JSON.stringify([...next]));
+                                progressPersisted = true;
+                        } catch (error) {
+                                console.error('Unable to persist quiz progress', error);
+                        }
+                }
+
+                if (!resultDialogOpen) {
+                        resultDialogOpen = true;
+                }
+        });
 </script>
 
 <svelte:head>
@@ -260,71 +349,96 @@
 	/>
 
 	<section class="flex flex-col gap-6">
-		{#if activeQuestion.kind === 'multiple-choice'}
-			<QuizMultipleChoice
-				question={activeQuestion}
-				eyebrow={quiz.topic ?? null}
-				selectedOptionId={activeAttempt.selectedOptionId}
-				status={toCardStatus(activeAttempt.status)}
-				showHint={activeAttempt.showHint}
-				locked={activeAttempt.locked}
-				feedback={activeAttempt.feedback}
-				showContinue={activeAttempt.showContinue}
-				on:select={(event) => handleOptionSelect(event.detail.optionId)}
-				on:submit={(event) => handleMultipleSubmit(event.detail.optionId)}
-				on:requestHint={handleHint}
-				on:dontKnow={handleDontKnow}
-				on:continue={goToNextQuestion}
-			/>
-		{:else if activeQuestion.kind === 'type-answer'}
-			<QuizTypeAnswer
-				question={activeQuestion}
-				eyebrow={quiz.topic ?? null}
-				value={activeAttempt.value}
-				status={toCardStatus(activeAttempt.status)}
-				showHint={activeAttempt.showHint}
-				locked={activeAttempt.locked}
-				feedback={activeAttempt.feedback}
-				showContinue={activeAttempt.showContinue}
-				on:input={(event) => handleTypeInput(event.detail.value)}
-				on:submit={(event) => handleTypeSubmit(event.detail.value)}
-				on:requestHint={handleHint}
-				on:dontKnow={handleDontKnow}
-				on:continue={goToNextQuestion}
-			/>
-		{/if}
-	</section>
-
-	{#if isQuizComplete}
-		<section
-			class="space-y-4 rounded-3xl border border-emerald-200/60 bg-emerald-50/70 p-6 text-emerald-900 shadow-[0_24px_60px_-40px_rgba(16,185,129,0.45)] dark:border-emerald-400/40 dark:bg-emerald-500/10 dark:text-emerald-100"
-		>
-			<h2 class="text-2xl font-semibold">Quiz complete</h2>
-			<p class="text-base leading-relaxed">
-				You answered {correctCount} of {quiz.questions.length} questions correctly.
-			</p>
-			<div class="flex flex-wrap gap-3 text-sm font-semibold">
-				<span
-					class="inline-flex items-center rounded-full bg-white/70 px-3 py-1 text-emerald-700 shadow-sm dark:bg-emerald-400/10 dark:text-emerald-100"
-				>
-					Correct · {correctCount}
-				</span>
-				<span
-					class="inline-flex items-center rounded-full bg-amber-100 px-3 py-1 text-amber-700 shadow-sm dark:bg-amber-500/20 dark:text-amber-100"
-				>
-					Incorrect · {incorrectCount}
-				</span>
-				{#if skippedCount > 0}
-					<span
-						class="inline-flex items-center rounded-full bg-slate-100 px-3 py-1 text-slate-600 shadow-sm dark:bg-slate-500/20 dark:text-slate-200"
-					>
-						Skipped · {skippedCount}
-					</span>
-				{/if}
-			</div>
-		</section>
-	{/if}
+                {#if activeQuestion.kind === 'multiple-choice'}
+                        <QuizMultipleChoice
+                                question={activeQuestion}
+                                eyebrow={quiz.topic ?? null}
+                                selectedOptionId={activeAttempt.selectedOptionId}
+                                status={toCardStatus(activeAttempt.status)}
+                                showHint={activeAttempt.showHint}
+                                locked={activeAttempt.locked}
+                                feedback={activeAttempt.feedback}
+                                showContinue={activeAttempt.showContinue}
+                                continueLabel={continueLabel}
+                                on:select={(event) => handleOptionSelect(event.detail.optionId)}
+                                on:submit={(event) => handleMultipleSubmit(event.detail.optionId)}
+                                on:requestHint={handleHint}
+                                on:dontKnow={handleDontKnow}
+                                on:continue={handleAdvanceFromAttempt}
+                        />
+                {:else if activeQuestion.kind === 'type-answer'}
+                        <QuizTypeAnswer
+                                question={activeQuestion}
+                                eyebrow={quiz.topic ?? null}
+                                value={activeAttempt.value}
+                                status={toCardStatus(activeAttempt.status)}
+                                showHint={activeAttempt.showHint}
+                                locked={activeAttempt.locked}
+                                feedback={activeAttempt.feedback}
+                                showContinue={activeAttempt.showContinue}
+                                continueLabel={continueLabel}
+                                on:input={(event) => handleTypeInput(event.detail.value)}
+                                on:submit={(event) => handleTypeSubmit(event.detail.value)}
+                                on:requestHint={handleHint}
+                                on:dontKnow={handleDontKnow}
+                                on:continue={handleAdvanceFromAttempt}
+                        />
+                {:else if activeQuestion.kind === 'info-card'}
+                        <QuizInfoCard
+                                question={activeQuestion}
+                                status={toCardStatus(activeAttempt.status)}
+                                continueLabel={continueLabel}
+                                on:continue={handleInfoContinue}
+                        />
+                {/if}
+        </section>
 </div>
+
+<Dialog.Root open={resultDialogOpen} onOpenChange={handleResultDialogChange}>
+        <Dialog.Content
+                class="result-dialog bg-background/98 max-w-lg overflow-hidden rounded-3xl p-0 shadow-[0_35px_90px_-40px_rgba(15,23,42,0.45)] dark:shadow-[0_35px_90px_-40px_rgba(2,6,23,0.75)]"
+        >
+                <div class="space-y-4 border-b border-border/60 px-6 py-6">
+                        <h2 class="text-foreground text-xl font-semibold tracking-tight md:text-2xl">
+                                Quiz complete
+                        </h2>
+                        <p class="text-muted-foreground text-sm leading-relaxed">
+                                You answered {correctCount} of {scoredAttempts.length} scored questions correctly.
+                        </p>
+                        <div class="flex flex-wrap gap-3 text-sm font-semibold">
+                                <span
+                                        class="inline-flex items-center rounded-full bg-emerald-100/80 px-3 py-1 text-emerald-700 shadow-sm dark:bg-emerald-500/15 dark:text-emerald-100"
+                                >
+                                        Correct · {correctCount}
+                                </span>
+                                <span
+                                        class="inline-flex items-center rounded-full bg-amber-100 px-3 py-1 text-amber-700 shadow-sm dark:bg-amber-500/20 dark:text-amber-100"
+                                >
+                                        Incorrect · {incorrectCount}
+                                </span>
+                                {#if skippedCount > 0}
+                                        <span
+                                                class="inline-flex items-center rounded-full bg-slate-100 px-3 py-1 text-slate-600 shadow-sm dark:bg-slate-500/20 dark:text-slate-200"
+                                        >
+                                                Skipped · {skippedCount}
+                                        </span>
+                                {/if}
+                        </div>
+                </div>
+                <div class="flex flex-col gap-3 px-6 py-6 sm:flex-row sm:items-center sm:justify-end">
+                        <Button
+                                variant="outline"
+                                class="w-full sm:w-auto sm:min-w-[9rem]"
+                                onclick={() => goto('/code')}
+                        >
+                                Back to plan
+                        </Button>
+                        <Button class="result-primary w-full sm:w-auto sm:min-w-[9rem]" onclick={() => goto('/code')}>
+                                Keep practicing
+                        </Button>
+                </div>
+        </Dialog.Content>
+</Dialog.Root>
 
 <Dialog.Root open={finishDialogOpen} onOpenChange={handleFinishDialogChange}>
 	<Dialog.Content
@@ -385,16 +499,27 @@
 		background: #0ea5e9 !important;
 	}
 
-	:global(.finish-continue) {
-		background: #f97316 !important;
-		color: #ffffff !important;
-		justify-content: center;
-		box-shadow: 0 18px 40px rgba(251, 146, 60, 0.35);
-	}
+        :global(.finish-continue) {
+                background: #f97316 !important;
+                color: #ffffff !important;
+                justify-content: center;
+                box-shadow: 0 18px 40px rgba(251, 146, 60, 0.35);
+        }
 
-	:global(.finish-continue:hover) {
-		background: #fb923c !important;
-	}
+        :global(.finish-continue:hover) {
+                background: #fb923c !important;
+        }
+
+        :global(.result-primary) {
+                background: #3b82f6 !important;
+                color: #ffffff !important;
+                justify-content: center;
+                box-shadow: 0 18px 40px rgba(59, 130, 246, 0.35);
+        }
+
+        :global(.result-primary:hover) {
+                background: #60a5fa !important;
+        }
 
 	@media (min-width: 40rem) {
 		:global(.finish-footer) {

--- a/web/src/types/shims.d.ts
+++ b/web/src/types/shims.d.ts
@@ -1,0 +1,4 @@
+declare module '@spark/llm/utils/gemini' {
+        type ConfigureGeminiOptions = Record<string, unknown>;
+        export function configureGemini(options?: ConfigureGeminiOptions): void;
+}


### PR DESCRIPTION
## Summary
- replace the code landing page timeline with a five-step DP-focused path that persists completion status locally
- add warm-up, topic deck, and review quiz definitions including info-card slides and completion modal with navigation back to /code
- extend quiz components with a reusable info card, result modal flow, and shims for missing modules to keep linting happy

## Testing
- npm --prefix web run lint

------
https://chatgpt.com/codex/tasks/task_e_68df72077654832e8c381e0ecd124dff