### PR TITLE
Add DP practice flow with progress tracking

### DIFF
--- a/web/src/lib/components/quiz/index.ts
+++ b/web/src/lib/components/quiz/index.ts
@@ -2,3 +2,4 @@ export { default as QuizQuestionCard } from './quiz-question-card.svelte';
 export { default as QuizProgress } from './quiz-progress.svelte';
 export { default as QuizMultipleChoice } from './quiz-multiple-choice.svelte';
 export { default as QuizTypeAnswer } from './quiz-type-answer.svelte';
+export { default as QuizInfoCard } from './quiz-info-card.svelte';

--- a/web/src/lib/components/quiz/quiz-info-card.svelte
+++ b/web/src/lib/components/quiz/quiz-info-card.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+        import { createEventDispatcher } from 'svelte';
+        import QuizQuestionCard from './quiz-question-card.svelte';
+        import { Button } from '$lib/components/ui/button/index.js';
+        import type { QuizInfoCardQuestion } from '$lib/types/quiz';
+
+        const dispatch = createEventDispatcher<{ continue: void }>();
+
+        type Props = {
+                question: QuizInfoCardQuestion;
+                eyebrow?: string | null;
+                continueLabel?: string;
+        };
+
+        let {
+                question,
+                eyebrow = undefined,
+                continueLabel = 'Continue'
+        }: Props = $props();
+
+        const paragraphs = $derived(
+                Array.isArray(question.body) ? [...question.body] : [question.body]
+        );
+        const resolvedLabel = $derived(question.actionLabel ?? continueLabel);
+
+        function handleContinue() {
+                dispatch('continue');
+        }
+</script>
+
+<QuizQuestionCard
+        title={question.prompt}
+        eyebrow={eyebrow}
+        status="neutral"
+        displayFooter={false}
+>
+        <div class="space-y-4 text-base leading-relaxed text-muted-foreground">
+                {#each paragraphs as paragraph, index}
+                        <p class="text-foreground/90">{paragraph}</p>
+                {/each}
+                <div class="pt-2">
+                        <Button size="lg" class="w-full sm:w-auto" onclick={handleContinue}>
+                                {resolvedLabel}
+                        </Button>
+                </div>
+        </div>
+</QuizQuestionCard>

--- a/web/src/lib/progress/session.ts
+++ b/web/src/lib/progress/session.ts
@@ -1,0 +1,112 @@
+export const PROGRESS_STORAGE_KEY = 'spark:code:progress';
+
+export type SessionStepId =
+        | 'warmup-quiz'
+        | 'topic-deck'
+        | 'dp-coin-change'
+        | 'dp-decode-ways'
+        | 'final-review-quiz';
+
+const QUIZ_STEP_LOOKUP: Record<string, SessionStepId> = {
+        'dp-warmup-basics': 'warmup-quiz',
+        'dp-topic-deck': 'topic-deck',
+        'dp-final-review': 'final-review-quiz'
+};
+
+const PROBLEM_STEP_LOOKUP: Record<string, SessionStepId> = {
+        'coin-change-ways': 'dp-coin-change',
+        'decode-ways': 'dp-decode-ways'
+};
+
+type StoredProgress = {
+        completed: SessionStepId[];
+};
+
+function getStorage(): Storage | null {
+        if (typeof window === 'undefined') {
+                return null;
+        }
+        try {
+                return window.localStorage;
+        } catch (error) {
+                console.error('Unable to access localStorage', error);
+                return null;
+        }
+}
+
+function parseProgress(raw: string | null): StoredProgress {
+        if (!raw) {
+                return { completed: [] };
+        }
+        try {
+                const parsed = JSON.parse(raw) as StoredProgress;
+                if (!Array.isArray(parsed.completed)) {
+                        return { completed: [] };
+                }
+                const unique = Array.from(new Set(parsed.completed));
+                return { completed: unique };
+        } catch (error) {
+                console.error('Failed to parse stored progress', error);
+                return { completed: [] };
+        }
+}
+
+function writeProgress(state: StoredProgress): void {
+        const storage = getStorage();
+        if (!storage) {
+                return;
+        }
+        const payload: StoredProgress = {
+                completed: Array.from(new Set(state.completed))
+        };
+        storage.setItem(PROGRESS_STORAGE_KEY, JSON.stringify(payload));
+}
+
+export function readCompletedSteps(): SessionStepId[] {
+        const storage = getStorage();
+        if (!storage) {
+                return [];
+        }
+        const snapshot = parseProgress(storage.getItem(PROGRESS_STORAGE_KEY));
+        return snapshot.completed;
+}
+
+export function markStepComplete(stepId: SessionStepId): void {
+        const storage = getStorage();
+        if (!storage) {
+                return;
+        }
+        const snapshot = parseProgress(storage.getItem(PROGRESS_STORAGE_KEY));
+        if (!snapshot.completed.includes(stepId)) {
+                snapshot.completed.push(stepId);
+                writeProgress(snapshot);
+        }
+}
+
+export function clearStep(stepId: SessionStepId): void {
+        const storage = getStorage();
+        if (!storage) {
+                return;
+        }
+        const snapshot = parseProgress(storage.getItem(PROGRESS_STORAGE_KEY));
+        const next = snapshot.completed.filter((entry) => entry !== stepId);
+        writeProgress({ completed: next });
+}
+
+export function getStepIdForQuiz(quizId: string): SessionStepId | undefined {
+        return QUIZ_STEP_LOOKUP[quizId];
+}
+
+export function getStepIdForProblem(problemId: string): SessionStepId | undefined {
+        return PROBLEM_STEP_LOOKUP[problemId];
+}
+
+export function getAllSessionSteps(): SessionStepId[] {
+        return [
+                'warmup-quiz',
+                'topic-deck',
+                'dp-coin-change',
+                'dp-decode-ways',
+                'final-review-quiz'
+        ];
+}

--- a/web/src/lib/server/quiz/mock-data.ts
+++ b/web/src/lib/server/quiz/mock-data.ts
@@ -1,77 +1,226 @@
 import type { QuizDefinition } from '$lib/types/quiz';
 
-export const dynamicProgrammingQuiz: QuizDefinition = {
-	id: 'dynamic-programming-foundations',
-	title: 'Dynamic Programming Starter Quiz',
-	topic: 'Dynamic Programming',
-	estimatedMinutes: 8,
-	description:
-		'Warm up with overlapping subproblems, transitions, and naming conventions used in interview-style DP questions.',
-	questions: [
-		{
-			kind: 'multiple-choice',
-			id: 'dp-overlap-properties',
-			prompt: 'Which pair of properties must hold before dynamic programming is a good fit?',
-			hint: 'Think about repeated work and whether substructures can be combined.',
-			explanation:
-				'Dynamic programming is valuable when subproblems repeat across branches and a global solution can be composed from optimal subproblem answers.',
-			options: [
-				{ id: 'A', label: 'A', text: 'Greedy-choice property and logarithmic complexity' },
-				{ id: 'B', label: 'B', text: 'Deterministic transitions and acyclic graphs' },
-				{ id: 'C', label: 'C', text: 'Overlapping subproblems and optimal substructure' },
-				{ id: 'D', label: 'D', text: 'Divide-and-conquer decomposition and prefix sums' }
-			],
-			correctOptionId: 'C'
-		},
-		{
-			kind: 'multiple-choice',
-			id: 'dp-space-optimisation',
-			prompt: 'When converting a two-dimensional DP table to a rolling array, what requirement must hold?',
-			hint: 'Look at how state transitions read previous rows or columns.',
-			explanation:
-				'Rolling arrays only work when each state depends on a limited window of prior states, such as the previous row or column, so overwritten entries are never read again.',
-			options: [
-				{ id: 'A', label: 'A', text: 'Each cell depends only on its diagonal neighbour' },
-				{ id: 'B', label: 'B', text: 'Transitions read no more than one previous layer' },
-				{ id: 'C', label: 'C', text: 'State transitions form a tree without cycles' },
-				{ id: 'D', label: 'D', text: 'The table indices are strictly increasing in both axes' }
-			],
-			correctOptionId: 'B'
-		},
-		{
-			kind: 'multiple-choice',
-			id: 'dp-transition-order',
-			prompt: 'Tabulation requires evaluating states in which order?',
-			hint: 'Follow the dependency graph of your transitions.',
-			explanation:
-				'Tabulation fills the table iteratively so every dependency is ready before a state is computed, typically moving from base cases up to the target state.',
-			options: [
-				{ id: 'A', label: 'A', text: 'Any order, because memoization handles recursion' },
-				{ id: 'B', label: 'B', text: 'Descending order from target state to base cases' },
-				{ id: 'C', label: 'C', text: 'A topological order that respects each transition' },
-				{ id: 'D', label: 'D', text: 'Breadth-first order by Manhattan distance' }
-			],
-			correctOptionId: 'C'
-		},
-		{
-			kind: 'type-answer',
-			id: 'dp-top-down-term',
-			prompt: 'What is the top-down technique that caches recursive results to avoid repeated work?',
-			hint: 'It pairs recursion with a hash map or array to remember answers.',
-			explanation:
-				'Recursive memoization stores the outcome of subproblems so subsequent calls can return instantly instead of recomputing.',
-			answer: 'memoization',
-			acceptableAnswers: ['memoisation']
-		},
-		{
-			kind: 'type-answer',
-			id: 'dp-table-name',
-			prompt: 'In a coin change tabulation with states dp[amount], what value does dp[0] store?',
-			hint: 'How many ways exist to form zero value?',
-			explanation:
-				'Setting dp[0] = 1 encodes the base case that there is exactly one way to form zero amount: choose no coins.',
-			answer: '1',
-			acceptableAnswers: ['one']
-		}
-	]
+export const dpWarmupQuiz: QuizDefinition = {
+        id: 'dp-warmup-basics',
+        title: 'Dynamic Programming Warmup',
+        description: 'Quick refresher on subproblems, memo tables, and transitions before diving deeper.',
+        topic: 'Dynamic Programming',
+        estimatedMinutes: 4,
+        stepId: 'warmup-quiz',
+        completionCtaLabel: 'Done — back to plan',
+        questions: [
+                {
+                        kind: 'multiple-choice',
+                        id: 'dp-warmup-overlap',
+                        prompt: 'What makes a problem a good fit for dynamic programming?',
+                        progressLabel: 'Warmup · Q1',
+                        hint: 'Focus on repeated work and reusable answers.',
+                        explanation:
+                                'Dynamic programming helps when subproblems repeat and the best answer can be composed from the best answers to those subproblems.',
+                        options: [
+                                { id: 'A', label: 'A', text: 'It has a binary search tree structure.' },
+                                {
+                                        id: 'B',
+                                        label: 'B',
+                                        text: 'Subproblems overlap and we can build the optimal answer from smaller ones.'
+                                },
+                                { id: 'C', label: 'C', text: 'It only works on sorted arrays.' },
+                                {
+                                        id: 'D',
+                                        label: 'D',
+                                        text: 'There are no base cases, so recursion can run forever.'
+                                }
+                        ],
+                        correctOptionId: 'B'
+                },
+                {
+                        kind: 'multiple-choice',
+                        id: 'dp-warmup-table-direction',
+                        prompt: 'When tabulating dp[i], what must be true about previously computed states?',
+                        progressLabel: 'Warmup · Q2',
+                        hint: 'Think about transition dependencies.',
+                        explanation:
+                                'We must visit states so every dependency is filled before we read it, otherwise dp[i] would look up stale data.',
+                        options: [
+                                { id: 'A', label: 'A', text: 'Every state only depends on larger indices.' },
+                                {
+                                        id: 'B',
+                                        label: 'B',
+                                        text: 'Dependencies may be unfilled; memoization will handle it.'
+                                },
+                                {
+                                        id: 'C',
+                                        label: 'C',
+                                        text: 'All dependencies are computed before the current state is evaluated.'
+                                },
+                                { id: 'D', label: 'D', text: 'dp arrays must always be iterated right to left.' }
+                        ],
+                        correctOptionId: 'C'
+                },
+                {
+                        kind: 'type-answer',
+                        id: 'dp-warmup-basecase',
+                        prompt: 'Fill in the blank: the base case dp[0] in a coin change count table should be _____.',
+                        progressLabel: 'Warmup · Q3',
+                        hint: 'How many ways can we make amount zero?',
+                        explanation:
+                                'We set dp[0] = 1 to represent the empty combination—the unique way to form amount zero.',
+                        answer: '1',
+                        acceptableAnswers: ['one']
+                }
+        ]
 };
+
+export const dpTopicDeck: QuizDefinition = {
+        id: 'dp-topic-deck',
+        title: 'DP on Counting Paths',
+        description: 'Step through a simple grid-walk recurrence, then test what you learned.',
+        topic: 'Dynamic Programming',
+        estimatedMinutes: 6,
+        stepId: 'topic-deck',
+        completionCtaLabel: 'Done — back to plan',
+        questions: [
+                {
+                        kind: 'info-card',
+                        id: 'dp-topic-setup',
+                        prompt: 'Scenario: counting grid paths',
+                        progressLabel: 'Topic · Intro',
+                        body: [
+                                'We start in the top-left corner of a grid and can move only right or down. dp[r][c] counts the ways to reach cell (r, c).',
+                                'Base cases: dp[0][c] = 1 and dp[r][0] = 1 because we can only move straight along the edge.'
+                        ],
+                        actionLabel: 'Next tip'
+                },
+                {
+                        kind: 'info-card',
+                        id: 'dp-topic-transition',
+                        prompt: 'Transition reminder',
+                        progressLabel: 'Topic · Step',
+                        body: [
+                                'For interior cells we add the top and left counts: dp[r][c] = dp[r - 1][c] + dp[r][c - 1].',
+                                'This is the core idea we will quiz on next.'
+                        ],
+                        actionLabel: 'Got it'
+                },
+                {
+                        kind: 'multiple-choice',
+                        id: 'dp-topic-base',
+                        prompt: 'What value should dp[0][3] hold in a 4×4 grid?',
+                        progressLabel: 'Topic · Q1',
+                        hint: 'Look at the top edge moves.',
+                        explanation:
+                                'The top row only allows moving right, so there is exactly one way to reach any cell along that row.',
+                        options: [
+                                { id: 'A', label: 'A', text: '0' },
+                                { id: 'B', label: 'B', text: '1' },
+                                { id: 'C', label: 'C', text: '3' },
+                                { id: 'D', label: 'D', text: '6' }
+                        ],
+                        correctOptionId: 'B'
+                },
+                {
+                        kind: 'multiple-choice',
+                        id: 'dp-topic-transition-mcq',
+                        prompt: 'dp[2][2] reads from which two neighbours?',
+                        progressLabel: 'Topic · Q2',
+                        hint: 'Trace the recurrence direction.',
+                        explanation:
+                                'We add paths from the cell above (1,2) and left (2,1) when computing dp[2][2].',
+                        options: [
+                                { id: 'A', label: 'A', text: '(1, 2) and (2, 1)' },
+                                { id: 'B', label: 'B', text: '(1, 1) and (3, 3)' },
+                                { id: 'C', label: 'C', text: '(0, 2) and (2, 0)' },
+                                { id: 'D', label: 'D', text: '(2, 3) and (3, 2)' }
+                        ],
+                        correctOptionId: 'A'
+                },
+                {
+                        kind: 'type-answer',
+                        id: 'dp-topic-final',
+                        prompt: 'How many paths reach the bottom-right of a 2×2 grid?',
+                        progressLabel: 'Topic · Q3',
+                        hint: 'Expand the recurrence or picture the moves.',
+                        explanation:
+                                'The recurrence yields 2 paths: right→down or down→right.',
+                        answer: '2',
+                        acceptableAnswers: ['two']
+                }
+        ]
+};
+
+export const dpFinalReviewQuiz: QuizDefinition = {
+        id: 'dp-final-review',
+        title: 'Final DP Review Quiz',
+        description: 'Lock in the day\'s concepts with a quick check on memoization and tabulation.',
+        topic: 'Dynamic Programming',
+        estimatedMinutes: 4,
+        stepId: 'final-review-quiz',
+        completionCtaLabel: 'Done — back to plan',
+        questions: [
+                {
+                        kind: 'multiple-choice',
+                        id: 'dp-review-memory',
+                        prompt: 'Why do we memoize the number of ways to climb n stairs?',
+                        progressLabel: 'Review · Q1',
+                        hint: 'Consider repeated branches in the recursion tree.',
+                        explanation:
+                                'Without memoization, each height splits into two calls that recompute the same counts. Storing results prevents exponential blow-up.',
+                        options: [
+                                {
+                                        id: 'A',
+                                        label: 'A',
+                                        text: 'Because recursion is impossible without a memo table.'
+                                },
+                                {
+                                        id: 'B',
+                                        label: 'B',
+                                        text: 'To reuse answers for the same remaining steps instead of recomputing them.'
+                                },
+                                {
+                                        id: 'C',
+                                        label: 'C',
+                                        text: 'To guarantee constant-time transitions.'
+                                },
+                                {
+                                        id: 'D',
+                                        label: 'D',
+                                        text: 'Because tabulation always uses more memory.'
+                                }
+                        ],
+                        correctOptionId: 'B'
+                },
+                {
+                        kind: 'multiple-choice',
+                        id: 'dp-review-space',
+                        prompt: 'When can we compress a 2D table into a 1D rolling array?',
+                        progressLabel: 'Review · Q2',
+                        hint: 'Check how each state reads previous data.',
+                        explanation:
+                                'We can roll the table when each cell only depends on the current row and the immediately previous row (or column), so overwriting does not break transitions.',
+                        options: [
+                                { id: 'A', label: 'A', text: 'Only if the graph of states has no cycles.' },
+                                {
+                                        id: 'B',
+                                        label: 'B',
+                                        text: 'Whenever transitions need at most one previously computed layer.'
+                                },
+                                { id: 'C', label: 'C', text: 'When the answer is zero.' },
+                                { id: 'D', label: 'D', text: 'Never; 2D tables cannot be compressed.' }
+                        ],
+                        correctOptionId: 'B'
+                },
+                {
+                        kind: 'type-answer',
+                        id: 'dp-review-base',
+                        prompt: 'What base value should memo[0] return for a Fibonacci-style recurrence?',
+                        progressLabel: 'Review · Q3',
+                        hint: 'Think about how many ways there are to reach step zero.',
+                        explanation:
+                                'Returning 0 would break the recurrence; we return 0th Fibonacci = 0 only when counting numbers. For ways to reach step zero, we return 1 to represent an empty path.',
+                        answer: '1',
+                        acceptableAnswers: ['one']
+                }
+        ]
+};
+
+export const quizRegistry: QuizDefinition[] = [dpWarmupQuiz, dpTopicDeck, dpFinalReviewQuiz];

--- a/web/src/lib/types/quiz.ts
+++ b/web/src/lib/types/quiz.ts
@@ -1,9 +1,12 @@
+import type { SessionStepId } from '$lib/progress/session';
+
 export type QuizQuestionBase = {
-	id: string;
-	prompt: string;
-	hint?: string;
-	explanation?: string;
-	audioLabel?: string;
+        id: string;
+        prompt: string;
+        hint?: string;
+        explanation?: string;
+        audioLabel?: string;
+        progressLabel?: string;
 };
 
 export type QuizChoiceOption = {
@@ -25,7 +28,16 @@ export type QuizTypeAnswerQuestion = QuizQuestionBase & {
 	placeholder?: string;
 };
 
-export type QuizQuestion = QuizMultipleChoiceQuestion | QuizTypeAnswerQuestion;
+export type QuizInfoCardQuestion = QuizQuestionBase & {
+        kind: 'info-card';
+        body: string | readonly string[];
+        actionLabel?: string;
+};
+
+export type QuizQuestion =
+        | QuizMultipleChoiceQuestion
+        | QuizTypeAnswerQuestion
+        | QuizInfoCardQuestion;
 
 export type QuizFeedbackTone = 'info' | 'success' | 'warning';
 
@@ -44,10 +56,12 @@ export type QuizProgressStep = {
 };
 
 export type QuizDefinition = {
-	id: string;
-	title: string;
-	description?: string;
-	topic?: string;
-	estimatedMinutes?: number;
-	questions: readonly QuizQuestion[];
+        id: string;
+        title: string;
+        description?: string;
+        topic?: string;
+        estimatedMinutes?: number;
+        stepId?: SessionStepId;
+        completionCtaLabel?: string;
+        questions: readonly QuizQuestion[];
 };

--- a/web/src/routes/(app)/code/quiz/[id]/+page.server.ts
+++ b/web/src/routes/(app)/code/quiz/[id]/+page.server.ts
@@ -1,14 +1,15 @@
 import type { PageServerLoad } from './$types';
-import { dynamicProgrammingQuiz } from '$lib/server/quiz/mock-data';
+import { quizRegistry } from '$lib/server/quiz/mock-data';
 import type { QuizDefinition } from '$lib/types/quiz';
 
-const registry = new Map<string, QuizDefinition>([
-	[dynamicProgrammingQuiz.id, dynamicProgrammingQuiz]
-]);
+const registry = new Map<string, QuizDefinition>(
+        quizRegistry.map((quiz) => [quiz.id, quiz] as const)
+);
+const fallbackQuiz = quizRegistry[0]!;
 
 export const load: PageServerLoad = async ({ params }) => {
 	const { id } = params;
-	const quiz = registry.get(id) ?? dynamicProgrammingQuiz;
+        const quiz = registry.get(id) ?? fallbackQuiz;
 
 	return {
 		quiz

--- a/web/src/routes/(app)/code/quiz/[id]/+page.svelte
+++ b/web/src/routes/(app)/code/quiz/[id]/+page.svelte
@@ -1,9 +1,16 @@
 <script lang="ts">
-	import { QuizProgress, QuizMultipleChoice, QuizTypeAnswer } from '$lib/components/quiz/index.js';
-	import { Button } from '$lib/components/ui/button/index.js';
-	import * as Dialog from '$lib/components/ui/dialog/index.js';
-	import type { QuizFeedback, QuizProgressStep, QuizQuestion } from '$lib/types/quiz';
-	import type { PageData } from './$types';
+        import {
+                QuizProgress,
+                QuizMultipleChoice,
+                QuizTypeAnswer,
+                QuizInfoCard
+        } from '$lib/components/quiz/index.js';
+        import { Button } from '$lib/components/ui/button/index.js';
+        import * as Dialog from '$lib/components/ui/dialog/index.js';
+        import type { QuizFeedback, QuizProgressStep, QuizQuestion } from '$lib/types/quiz';
+        import type { PageData } from './$types';
+        import { markStepComplete, getStepIdForQuiz } from '$lib/progress/session';
+        import { goto } from '$app/navigation';
 
 	type AttemptStatus = 'pending' | 'correct' | 'incorrect' | 'skipped';
 
@@ -46,7 +53,11 @@
 
 	let attempts = $state(quiz.questions.map((_, idx) => createInitialAttempt(idx === 0)));
 	let currentIndex = $state(0);
-	let finishDialogOpen = $state(false);
+        let finishDialogOpen = $state(false);
+        let completionDialogOpen = $state(false);
+        let completionDialogSeen = $state(false);
+        let hasMarkedComplete = $state(false);
+        const stepId = $derived(getStepIdForQuiz(quiz.id));
 
 	function handleFinishDialogChange(open: boolean) {
 		finishDialogOpen = open;
@@ -58,11 +69,11 @@
 
 	const activeQuestion = $derived(quiz.questions[currentIndex] as QuizQuestion);
 	const activeAttempt = $derived(attempts[currentIndex] ?? createInitialAttempt());
-	const progressSteps = $derived(
-		quiz.questions.map<QuizProgressStep>((_, index) => {
-			const attempt = attempts[index];
-			const label = `Question ${index + 1}`;
-			if (!attempt || attempt.status === 'pending') {
+        const progressSteps = $derived(
+                quiz.questions.map<QuizProgressStep>((question, index) => {
+                        const attempt = attempts[index];
+                        const label = question.progressLabel ?? `Step ${index + 1}`;
+                        if (!attempt || attempt.status === 'pending') {
 				return {
 					status: index === currentIndex ? 'active' : attempt?.seen ? 'seen' : 'pending',
 					label
@@ -88,14 +99,14 @@
 		quiz.questions.length - correctCount - incorrectCount - skippedCount
 	);
 
-	function goToQuestion(index: number) {
-		if (index < 0 || index >= quiz.questions.length || index === currentIndex) {
-			return;
+        function goToQuestion(index: number) {
+                if (index < 0 || index >= quiz.questions.length || index === currentIndex) {
+                        return;
 		}
 		const target = attempts[index];
-		if (target && (target.status !== 'pending' || target.seen)) {
-			currentIndex = index;
-		}
+        if (target && (target.status !== 'pending' || target.seen)) {
+                currentIndex = index;
+        }
 	}
 
 	function handleOptionSelect(optionId: string) {
@@ -115,13 +126,13 @@
 		const correctOption = question.options.find((option) => option.id === question.correctOptionId);
 		const isCorrect = optionId === question.correctOptionId;
 
-		updateAttempt(currentIndex, (prev) => ({
-			...prev,
-			status: isCorrect ? 'correct' : 'incorrect',
-			locked: true,
-			selectedOptionId: optionId,
-			showContinue: true,
-			feedback: isCorrect
+                updateAttempt(currentIndex, (prev) => ({
+                        ...prev,
+                        status: isCorrect ? 'correct' : 'incorrect',
+                        locked: true,
+                        selectedOptionId: optionId,
+                        showContinue: true,
+                        feedback: isCorrect
 				? {
 						heading: 'Nice work',
 						message: 'That matches the DP condition we rely on here.'
@@ -135,12 +146,12 @@
 
 	function handleHint() {
 		updateAttempt(currentIndex, (prev) => ({ ...prev, showHint: true }));
-	}
+        }
 
-	function handleDontKnow() {
-		const question = quiz.questions[currentIndex];
+        function handleDontKnow() {
+                const question = quiz.questions[currentIndex];
 
-		if (question.kind === 'multiple-choice') {
+                if (question.kind === 'multiple-choice') {
 			const correctOption = question.options.find(
 				(option) => option.id === question.correctOptionId
 			);
@@ -155,13 +166,13 @@
 				}
 			}));
 			return;
-		}
+                }
 
-		updateAttempt(currentIndex, (prev) => ({
-			...prev,
-			status: 'incorrect',
-			locked: true,
-			showContinue: true,
+                updateAttempt(currentIndex, (prev) => ({
+                        ...prev,
+                        status: 'incorrect',
+                        locked: true,
+                        showContinue: true,
 			feedback: {
 				heading: 'No worries',
 				message: 'Read the explanation and keep the momentum going.'
@@ -192,12 +203,12 @@
 		);
 		const isCorrect = accepted.includes(trimmed.toLowerCase());
 
-		updateAttempt(currentIndex, (prev) => ({
-			...prev,
-			value: trimmed,
-			status: isCorrect ? 'correct' : 'incorrect',
-			locked: true,
-			showContinue: true,
+                updateAttempt(currentIndex, (prev) => ({
+                        ...prev,
+                        value: trimmed,
+                        status: isCorrect ? 'correct' : 'incorrect',
+                        locked: true,
+                        showContinue: true,
 			feedback: isCorrect
 				? {
 						heading: 'Great answer',
@@ -208,42 +219,82 @@
 						message: `The answer we needed appears below—study it and move forward.`
 					}
 		}));
-	}
+        }
 
-	function goToNextQuestion() {
-		if (currentIndex < quiz.questions.length - 1) {
-			currentIndex += 1;
-		}
-	}
+        function goToNextQuestion() {
+                if (currentIndex >= quiz.questions.length - 1) {
+                        completionDialogOpen = true;
+                        completionDialogSeen = true;
+                        return;
+                }
+                currentIndex += 1;
+        }
 
-	function handleFinishEarly() {
-		attempts = attempts.map((attempt) =>
-			attempt.status === 'pending'
+        function handleFinishEarly() {
+                attempts = attempts.map((attempt) =>
+                        attempt.status === 'pending'
 				? {
 						...attempt,
 						status: 'skipped',
 						locked: true,
 						showContinue: false
 					}
-				: attempt
-		);
-		finishDialogOpen = false;
-		currentIndex = Math.min(currentIndex, quiz.questions.length - 1);
-	}
+                                        : attempt
+                );
+                finishDialogOpen = false;
+                currentIndex = Math.min(currentIndex, quiz.questions.length - 1);
+                completionDialogOpen = true;
+                completionDialogSeen = true;
+        }
 
-	function resetQuiz() {
-		attempts = quiz.questions.map((_, idx) => createInitialAttempt(idx === 0));
-		currentIndex = 0;
-		finishDialogOpen = false;
-	}
+        function resetQuiz() {
+                attempts = quiz.questions.map((_, idx) => createInitialAttempt(idx === 0));
+                currentIndex = 0;
+                finishDialogOpen = false;
+                completionDialogOpen = false;
+                completionDialogSeen = false;
+                hasMarkedComplete = false;
+        }
 
 	// Mark the current question as seen whenever it becomes active
-	$effect(() => {
-		const attempt = attempts[currentIndex];
-		if (attempt && !attempt.seen) {
-			updateAttempt(currentIndex, (prev) => ({ ...prev, seen: true }));
-		}
-	});
+        $effect(() => {
+                const attempt = attempts[currentIndex];
+                if (attempt && !attempt.seen) {
+                        updateAttempt(currentIndex, (prev) => ({ ...prev, seen: true }));
+                }
+        });
+
+        const finalContinueLabel = $derived(quiz.completionCtaLabel ?? 'Done — back to plan');
+        const isLastQuestion = $derived(currentIndex === quiz.questions.length - 1);
+
+        function handleInfoContinue() {
+                updateAttempt(currentIndex, (prev) => ({
+                        ...prev,
+                        status: 'correct',
+                        locked: true,
+                        showContinue: false,
+                        feedback: null
+                }));
+                goToNextQuestion();
+        }
+
+        function handleCompletionDialogChange(open: boolean) {
+                completionDialogOpen = open;
+                if (!open && isQuizComplete) {
+                        void goto('/code');
+                }
+        }
+
+        function handleCompletionAction() {
+                completionDialogOpen = false;
+        }
+
+        $effect(() => {
+                if (isQuizComplete && !hasMarkedComplete && stepId) {
+                        markStepComplete(stepId);
+                        hasMarkedComplete = true;
+                }
+        });
 </script>
 
 <svelte:head>
@@ -259,72 +310,92 @@
 		on:finish={() => (finishDialogOpen = true)}
 	/>
 
-	<section class="flex flex-col gap-6">
-		{#if activeQuestion.kind === 'multiple-choice'}
-			<QuizMultipleChoice
-				question={activeQuestion}
-				eyebrow={quiz.topic ?? null}
-				selectedOptionId={activeAttempt.selectedOptionId}
-				status={toCardStatus(activeAttempt.status)}
-				showHint={activeAttempt.showHint}
-				locked={activeAttempt.locked}
-				feedback={activeAttempt.feedback}
-				showContinue={activeAttempt.showContinue}
-				on:select={(event) => handleOptionSelect(event.detail.optionId)}
-				on:submit={(event) => handleMultipleSubmit(event.detail.optionId)}
-				on:requestHint={handleHint}
-				on:dontKnow={handleDontKnow}
-				on:continue={goToNextQuestion}
-			/>
-		{:else if activeQuestion.kind === 'type-answer'}
-			<QuizTypeAnswer
-				question={activeQuestion}
-				eyebrow={quiz.topic ?? null}
-				value={activeAttempt.value}
-				status={toCardStatus(activeAttempt.status)}
-				showHint={activeAttempt.showHint}
-				locked={activeAttempt.locked}
-				feedback={activeAttempt.feedback}
-				showContinue={activeAttempt.showContinue}
-				on:input={(event) => handleTypeInput(event.detail.value)}
-				on:submit={(event) => handleTypeSubmit(event.detail.value)}
-				on:requestHint={handleHint}
-				on:dontKnow={handleDontKnow}
-				on:continue={goToNextQuestion}
-			/>
-		{/if}
-	</section>
-
-	{#if isQuizComplete}
-		<section
-			class="space-y-4 rounded-3xl border border-emerald-200/60 bg-emerald-50/70 p-6 text-emerald-900 shadow-[0_24px_60px_-40px_rgba(16,185,129,0.45)] dark:border-emerald-400/40 dark:bg-emerald-500/10 dark:text-emerald-100"
-		>
-			<h2 class="text-2xl font-semibold">Quiz complete</h2>
-			<p class="text-base leading-relaxed">
-				You answered {correctCount} of {quiz.questions.length} questions correctly.
-			</p>
-			<div class="flex flex-wrap gap-3 text-sm font-semibold">
-				<span
-					class="inline-flex items-center rounded-full bg-white/70 px-3 py-1 text-emerald-700 shadow-sm dark:bg-emerald-400/10 dark:text-emerald-100"
-				>
-					Correct · {correctCount}
-				</span>
-				<span
-					class="inline-flex items-center rounded-full bg-amber-100 px-3 py-1 text-amber-700 shadow-sm dark:bg-amber-500/20 dark:text-amber-100"
-				>
-					Incorrect · {incorrectCount}
-				</span>
-				{#if skippedCount > 0}
-					<span
-						class="inline-flex items-center rounded-full bg-slate-100 px-3 py-1 text-slate-600 shadow-sm dark:bg-slate-500/20 dark:text-slate-200"
-					>
-						Skipped · {skippedCount}
-					</span>
-				{/if}
-			</div>
-		</section>
-	{/if}
+        <section class="flex flex-col gap-6">
+                {#if activeQuestion.kind === 'multiple-choice'}
+                        <QuizMultipleChoice
+                                question={activeQuestion}
+                                eyebrow={quiz.topic ?? null}
+                                selectedOptionId={activeAttempt.selectedOptionId}
+                                status={toCardStatus(activeAttempt.status)}
+                                showHint={activeAttempt.showHint}
+                                locked={activeAttempt.locked}
+                                feedback={activeAttempt.feedback}
+                                showContinue={activeAttempt.showContinue}
+                                continueLabel={isLastQuestion ? finalContinueLabel : 'Continue'}
+                                on:select={(event) => handleOptionSelect(event.detail.optionId)}
+                                on:submit={(event) => handleMultipleSubmit(event.detail.optionId)}
+                                on:requestHint={handleHint}
+                                on:dontKnow={handleDontKnow}
+                                on:continue={goToNextQuestion}
+                        />
+                {:else if activeQuestion.kind === 'type-answer'}
+                        <QuizTypeAnswer
+                                question={activeQuestion}
+                                eyebrow={quiz.topic ?? null}
+                                value={activeAttempt.value}
+                                status={toCardStatus(activeAttempt.status)}
+                                showHint={activeAttempt.showHint}
+                                locked={activeAttempt.locked}
+                                feedback={activeAttempt.feedback}
+                                showContinue={activeAttempt.showContinue}
+                                continueLabel={isLastQuestion ? finalContinueLabel : 'Continue'}
+                                on:input={(event) => handleTypeInput(event.detail.value)}
+                                on:submit={(event) => handleTypeSubmit(event.detail.value)}
+                                on:requestHint={handleHint}
+                                on:dontKnow={handleDontKnow}
+                                on:continue={goToNextQuestion}
+                        />
+                {:else if activeQuestion.kind === 'info-card'}
+                        <QuizInfoCard
+                                question={activeQuestion}
+                                eyebrow={quiz.topic ?? null}
+                                continueLabel={isLastQuestion ? finalContinueLabel : 'Continue'}
+                                on:continue={handleInfoContinue}
+                        />
+                {/if}
+        </section>
 </div>
+
+<Dialog.Root open={completionDialogOpen} onOpenChange={handleCompletionDialogChange}>
+        <Dialog.Content
+                class="completion-dialog bg-background/98 max-w-xl overflow-hidden rounded-3xl p-0 shadow-[0_35px_90px_-40px_rgba(15,23,42,0.45)] dark:shadow-[0_35px_90px_-40px_rgba(2,6,23,0.75)]"
+        >
+                <div class="border-border/70 space-y-3 border-b bg-gradient-to-br from-emerald-200/30 via-background to-background px-6 py-6 dark:from-emerald-400/20">
+                        <h2 class="text-foreground text-xl font-semibold tracking-tight md:text-2xl">
+                                Quiz complete
+                        </h2>
+                        <p class="text-muted-foreground text-sm leading-relaxed">
+                                You answered {correctCount} of {quiz.questions.length} question(s) correctly.
+                        </p>
+                </div>
+                <div class="space-y-6 px-6 py-6">
+                        <div class="flex flex-wrap gap-3 text-sm font-semibold">
+                                <span
+                                        class="inline-flex items-center rounded-full bg-emerald-500/10 px-3 py-1 text-emerald-700 shadow-sm ring-1 ring-emerald-400/40 dark:bg-emerald-400/10 dark:text-emerald-100"
+                                >
+                                        Correct · {correctCount}
+                                </span>
+                                <span
+                                        class="inline-flex items-center rounded-full bg-amber-500/10 px-3 py-1 text-amber-700 shadow-sm ring-1 ring-amber-400/40 dark:bg-amber-500/20 dark:text-amber-100"
+                                >
+                                        Incorrect · {incorrectCount}
+                                </span>
+                                {#if skippedCount > 0}
+                                        <span
+                                                class="inline-flex items-center rounded-full bg-slate-500/10 px-3 py-1 text-slate-700 shadow-sm ring-1 ring-slate-400/40 dark:bg-slate-500/20 dark:text-slate-200"
+                                        >
+                                                Skipped · {skippedCount}
+                                        </span>
+                                {/if}
+                        </div>
+                        <div class="flex flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-end">
+                                <Button class="w-full sm:w-auto sm:min-w-[10rem]" onclick={handleCompletionAction}>
+                                        {finalContinueLabel}
+                                </Button>
+                        </div>
+                </div>
+        </Dialog.Content>
+</Dialog.Root>
 
 <Dialog.Root open={finishDialogOpen} onOpenChange={handleFinishDialogChange}>
 	<Dialog.Content
@@ -355,6 +426,23 @@
 </Dialog.Root>
 
 <style>
+/* Completion dialog: matching radius and subtle border */
+:global(.completion-dialog) {
+    --completion-border: rgba(16, 185, 129, 0.35);
+    border-radius: 1.5rem;
+    background: color-mix(in srgb, hsl(var(--background)) 98%, transparent 2%);
+    box-shadow:
+        0 0 0 1px var(--completion-border),
+        0 35px 90px -40px rgba(15, 23, 42, 0.4);
+}
+
+:global([data-theme='dark'] .completion-dialog) {
+    --completion-border: rgba(52, 211, 153, 0.4);
+    box-shadow:
+        0 0 0 1px var(--completion-border),
+        0 35px 90px -40px rgba(2, 6, 23, 0.75);
+}
+
 /* Dialog container: strong, theme-aware border for clarity */
 :global(.finish-dialog) {
     --finish-border: rgba(15, 23, 42, 0.18);


### PR DESCRIPTION
## Summary
- refocus the /code dashboard on a five-step dynamic programming plan and read/write session progress from local storage
- add warmup, topic deck, and final review quiz definitions plus an info-card slide component
- show quiz completion stats in a modal that routes back to the plan and provide a problem-level "Done" action

## Testing
- npm -w web run lint *(fails: `svelte-kit` not found in PATH)*

------
https://chatgpt.com/codex/tasks/task_e_68df72077654832e8c381e0ecd124dff